### PR TITLE
JWT 기반 회원가입 로그인 및 인터셉터 인증 흐름 구현 #10

### DIFF
--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -37,13 +37,13 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const glob = require('@actions/glob');
+            const actionsGlob = require('@actions/glob');
 
             const COMMENT_MARKER = '<!-- ktlint-ci-bot -->';
             const prNumber = context.payload.pull_request.number;
 
             // ── 1. ktlint XML 리포트 파일 수집 ──
-            const globber = await glob.create('**/build/reports/ktlint/**/*.xml');
+            const globber = await actionsGlob.create('**/build/reports/ktlint/**/*.xml');
             const reportFiles = await globber.glob();
 
             // ── 2. XML 리포트 파싱 (간이 파서) ──

--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -37,14 +37,32 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const actionsGlob = require('@actions/glob');
 
             const COMMENT_MARKER = '<!-- ktlint-ci-bot -->';
             const prNumber = context.payload.pull_request.number;
 
             // ── 1. ktlint XML 리포트 파일 수집 ──
-            const globber = await actionsGlob.create('**/build/reports/ktlint/**/*.xml');
-            const reportFiles = await globber.glob();
+            function findXmlFiles(dir) {
+              let results = [];
+              if (!fs.existsSync(dir)) return results;
+              for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const full = path.join(dir, entry.name);
+                if (entry.isDirectory()) {
+                  results = results.concat(findXmlFiles(full));
+                } else if (entry.name.endsWith('.xml')) {
+                  results.push(full);
+                }
+              }
+              return results;
+            }
+
+            const workspace = process.env.GITHUB_WORKSPACE;
+            // 각 모듈의 build/reports/ktlint 디렉토리만 탐색
+            const reportFiles = fs.readdirSync(workspace, { withFileTypes: true })
+              .filter(d => d.isDirectory())
+              .map(d => path.join(workspace, d.name, 'build', 'reports', 'ktlint'))
+              .filter(d => fs.existsSync(d))
+              .flatMap(d => findXmlFiles(d));
 
             // ── 2. XML 리포트 파싱 (간이 파서) ──
             const violations = [];

--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -1,0 +1,133 @@
+name: ktlint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  ktlint:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run ktlint
+        id: ktlint
+        continue-on-error: true
+        run: ./gradlew ktlintCheck --continue
+
+      - name: Parse ktlint reports and comment on PR
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const glob = require('@actions/glob');
+
+            const COMMENT_MARKER = '<!-- ktlint-ci-bot -->';
+            const prNumber = context.payload.pull_request.number;
+
+            // ── 1. ktlint XML 리포트 파일 수집 ──
+            const globber = await glob.create('**/build/reports/ktlint/**/*.xml');
+            const reportFiles = await globber.glob();
+
+            // ── 2. XML 리포트 파싱 (간이 파서) ──
+            const violations = [];
+            for (const file of reportFiles) {
+              const content = fs.readFileSync(file, 'utf8');
+              const fileMatches = content.matchAll(/<file\s+name="([^"]+)">/g);
+              for (const fileMatch of fileMatches) {
+                const filePath = fileMatch[1];
+                // 프로젝트 루트 기준 상대경로로 변환
+                const relativePath = filePath.replace(process.env.GITHUB_WORKSPACE + '/', '');
+                const fileSection = content.substring(fileMatch.index);
+                const endIndex = fileSection.indexOf('</file>');
+                const section = fileSection.substring(0, endIndex);
+                const errorMatches = section.matchAll(/<error\s+line="(\d+)"[^>]*message="([^"]+)"[^>]*\/>/g);
+                for (const errorMatch of errorMatches) {
+                  violations.push({
+                    file: relativePath,
+                    line: errorMatch[1],
+                    message: errorMatch[2]
+                  });
+                }
+              }
+            }
+
+            // ── 3. 기존 봇 코멘트 찾기 ──
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+            const existingComment = comments.find(c => c.body && c.body.includes(COMMENT_MARKER));
+
+            // ── 4. 위반 없음 → 기존 코멘트 삭제 후 종료 ──
+            if (violations.length === 0) {
+              if (existingComment) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id
+                });
+                console.log('위반 없음 — 기존 코멘트를 삭제했습니다.');
+              }
+              console.log('ktlint 검사 통과');
+              return;
+            }
+
+            // ── 5. 위반 있음 → 코멘트 작성 ──
+            const maxRows = 30;
+            const truncated = violations.length > maxRows;
+            const displayViolations = violations.slice(0, maxRows);
+
+            const tableRows = displayViolations
+              .map(v => `| ${v.file} | ${v.line} | ${v.message} |`)
+              .join('\n');
+
+            let body = `${COMMENT_MARKER}\n`;
+            body += `### ktlint 검사 실패 (${violations.length}건)\n\n`;
+            body += `| 파일 | 줄 | 위반 내용 |\n`;
+            body += `|------|-----|----------|\n`;
+            body += `${tableRows}\n`;
+            if (truncated) {
+              body += `\n_...외 ${violations.length - maxRows}건 (전체 목록은 Actions 로그를 확인하세요)_\n`;
+            }
+            body += `\n> 로컬에서 \`./gradlew ktlintFormat\` 실행하면 자동 수정 가능한 항목은 자동으로 고쳐집니다.\n`;
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: body
+              });
+              console.log('기존 코멘트를 업데이트했습니다.');
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body
+              });
+              console.log('새 코멘트를 생성했습니다.');
+            }
+
+      - name: Fail if ktlint found violations
+        if: steps.ktlint.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -64,7 +64,40 @@ jobs:
               .filter(d => fs.existsSync(d))
               .flatMap(d => findXmlFiles(d));
 
-            // ── 2. XML 리포트 파싱 (간이 파서) ──
+            // ── 2. 주요 ktlint 메시지 한글 매핑 ──
+            const translations = [
+              [/Imports must be ordered in lexicographic order.*/i, 'import 문을 알파벳순으로 정렬해야 합니다'],
+              [/Expected a single space/i, '공백이 하나만 있어야 합니다'],
+              [/Unnecessary long whitespace/i, '불필요한 긴 공백이 있습니다'],
+              [/A comment in a 'value_parameter_list' is only allowed when placed on a separate line.*/i, '파라미터 목록의 주석은 별도 줄에 작성해야 합니다 (자동 수정 불가)'],
+              [/A comment in a 'value_argument_list' is only allowed when placed on a separate line.*/i, '인자 목록의 주석은 별도 줄에 작성해야 합니다 (자동 수정 불가)'],
+              [/A \(block or EOL\) comment inside or on same line after a 'value_parameter' is not allowed.*/i, '파라미터 뒤 같은 줄의 주석은 허용되지 않습니다 (자동 수정 불가)'],
+              [/Class body should not start with blank line/i, '클래스 본문이 빈 줄로 시작하면 안 됩니다'],
+              [/A multiline expression should start on a new line/i, '여러 줄 표현식은 새 줄에서 시작해야 합니다'],
+              [/Unexpected indentation \((\d+)\) \(should be (\d+)\)/i, (m) => `잘못된 들여쓰기 (${m[1]}) (${m[2]}이어야 합니다)`],
+              [/File must end with a newline/i, '파일 끝에 빈 줄(\\n)이 있어야 합니다'],
+              [/Newline expected after opening parenthesis/i, '여는 괄호 뒤에 줄바꿈이 필요합니다'],
+              [/Newline expected before closing parenthesis/i, '닫는 괄호 앞에 줄바꿈이 필요합니다'],
+              [/Missing newline before "\)"/i, '닫는 괄호 앞에 줄바꿈이 필요합니다'],
+              [/Parameter should start on a newline/i, '파라미터는 새 줄에서 시작해야 합니다'],
+              [/Unnecessary trailing comma before "\)"/i, '닫는 괄호 앞의 불필요한 쉼표입니다'],
+              [/Unexpected whitespace/i, '불필요한 공백이 있습니다'],
+              [/Unexpected spacing before "\)"/i, '닫는 괄호 앞에 불필요한 공백이 있습니다'],
+              [/No blank lines in chained calls/i, '체이닝 호출 사이에 빈 줄을 넣지 마세요'],
+              [/Wildcard import/i, '와일드카드(.*) import는 허용되지 않습니다'],
+              [/No empty first line in a class body/i, '클래스 본문 첫 줄이 비어있으면 안 됩니다'],
+              [/Missing trailing comma before "\)"/i, '닫는 괄호 앞에 후행 쉼표가 필요합니다'],
+            ];
+
+            function translate(msg) {
+              for (const [pattern, replacement] of translations) {
+                const match = msg.match(pattern);
+                if (match) return typeof replacement === 'function' ? replacement(match) : replacement;
+              }
+              return msg;
+            }
+
+            // ── 3. XML 리포트 파싱 ──
             const violations = [];
             for (const file of reportFiles) {
               const content = fs.readFileSync(file, 'utf8');
@@ -81,13 +114,13 @@ jobs:
                   violations.push({
                     file: relativePath,
                     line: errorMatch[1],
-                    message: errorMatch[2]
+                    message: translate(errorMatch[2])
                   });
                 }
               }
             }
 
-            // ── 3. 기존 봇 코멘트 찾기 ──
+            // ── 4. 기존 봇 코멘트 찾기 ──
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -95,7 +128,7 @@ jobs:
             });
             const existingComment = comments.find(c => c.body && c.body.includes(COMMENT_MARKER));
 
-            // ── 4. 위반 없음 → 기존 코멘트 삭제 후 종료 ──
+            // ── 5. 위반 없음 → 기존 코멘트 삭제 후 종료 ──
             if (violations.length === 0) {
               if (existingComment) {
                 await github.rest.issues.deleteComment({
@@ -109,7 +142,7 @@ jobs:
               return;
             }
 
-            // ── 5. 위반 있음 → 코멘트 작성 ──
+            // ── 6. 위반 있음 → 코멘트 작성 ──
             const maxRows = 30;
             const truncated = violations.length > maxRows;
             const displayViolations = violations.slice(0, maxRows);

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,205 @@
+name: PR Size Labeler
+
+# PR이 새로 열리거나, 새로운 커밋이 푸시(동기화)되거나, 다시 열릴 때 실행됩니다.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label-pr-size:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # PR에 라벨을 달기 위한 쓰기 권한
+      issues: write        # 라벨 자체를 생성하기 위한 권한
+      contents: read       # .gitattributes 파일 읽기 및 파일 목록 조회
+
+    steps:
+      - name: Checkout repository (for .gitattributes)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .gitattributes
+          sparse-checkout-cone-mode: false
+
+      - name: Calculate and Add Size Label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            // ── 1. .gitattributes에서 제외할 패턴 파싱 ──
+            const excludePatterns = [];
+            const gitattributesPath = path.join(process.env.GITHUB_WORKSPACE, '.gitattributes');
+            if (fs.existsSync(gitattributesPath)) {
+              const content = fs.readFileSync(gitattributesPath, 'utf8');
+              for (const line of content.split('\n')) {
+                if (line.includes('linguist-generated=true')) {
+                  const pattern = line.split(/\s+/)[0];
+                  if (pattern) excludePatterns.push(pattern);
+                }
+              }
+              console.log(`제외 패턴: ${JSON.stringify(excludePatterns)}`);
+            } else {
+              console.log('.gitattributes 파일이 없습니다. 모든 파일을 계산에 포함합니다.');
+            }
+
+            // ── 2. PR의 변경 파일 목록 가져오기 ──
+            const pr = context.payload.pull_request;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100
+            });
+
+            // glob 스타일 패턴을 간단한 정규식으로 변환하는 헬퍼
+            function matchesPattern(filename, pattern) {
+              // "*.ext" → 확장자 매칭
+              if (pattern.startsWith('*.')) {
+                return filename.endsWith(pattern.slice(1));
+              }
+              // "dir/**" → 디렉토리 매칭
+              if (pattern.endsWith('/**')) {
+                return filename.startsWith(pattern.slice(0, -3));
+              }
+              // 정확한 파일명 매칭
+              return filename === pattern;
+            }
+
+            // ── 3. 제외 파일을 빼고 순수 변경량 계산 ──
+            let totalChanges = 0;
+            let excludedChanges = 0;
+            for (const file of files) {
+              const fileChanges = file.additions + file.deletions;
+              const isExcluded = excludePatterns.some(p => matchesPattern(file.filename, p));
+              if (isExcluded) {
+                excludedChanges += fileChanges;
+                console.log(`  [제외] ${file.filename} (${fileChanges}줄)`);
+              } else {
+                totalChanges += fileChanges;
+              }
+            }
+
+            console.log(`순수 변경 줄 수: ${totalChanges} (제외된 줄 수: ${excludedChanges})`);
+
+            // ── 4. 크기 기준(Threshold) 설정 ──
+            let sizeLabel = '';
+            if (totalChanges < 10) sizeLabel = 'size/XS';
+            else if (totalChanges < 30) sizeLabel = 'size/S';
+            else if (totalChanges < 100) sizeLabel = 'size/M';
+            else if (totalChanges < 500) sizeLabel = 'size/L';
+            else if (totalChanges < 1000) sizeLabel = 'size/XL';
+            else sizeLabel = 'size/XXL';
+
+            // ── 5. 라벨 색상 설정 ──
+            const labelColors = {
+              'size/XS': '3CBF00',
+              'size/S': '5D9801',
+              'size/M': '7F7203',
+              'size/L': 'A14C05',
+              'size/XL': 'C32600',
+              'size/XXL': 'E50000'
+            };
+
+            // ── 6. 현재 PR 라벨 확인 ──
+            const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number
+            });
+            const currentLabelNames = currentLabels.map(label => label.name);
+
+            if (currentLabelNames.includes(sizeLabel)) {
+              console.log(`이미 올바른 라벨(${sizeLabel})이 달려있습니다.`);
+              return;
+            }
+
+            // ── 7. 기존 size/ 라벨 제거 ──
+            for (const label of currentLabelNames) {
+              if (label.startsWith('size/') && label !== sizeLabel) {
+                console.log(`기존 라벨 제거: ${label}`);
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: label
+                });
+              }
+            }
+
+            // ── 8. 라벨이 레포지토리에 없으면 생성 ──
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: sizeLabel
+              });
+            } catch (error) {
+              if (error.status === 404) {
+                console.log(`라벨 새로 생성: ${sizeLabel}`);
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: sizeLabel,
+                  color: labelColors[sizeLabel] || 'ffffff'
+                });
+              }
+            }
+
+            // ── 9. 새 라벨 부착 ──
+            console.log(`새 라벨 추가: ${sizeLabel}`);
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: [sizeLabel]
+            });
+
+            // ── 10. PR 안내 코멘트 남기기 (기존 코멘트가 있으면 업데이트) ──
+            const sizeDescriptions = {
+              'size/XS': '아주 작은 변경입니다. 빠르게 리뷰 가능합니다! ⚡',
+              'size/S': '작은 변경입니다. 가볍게 리뷰해 주세요. ✅',
+              'size/M': '중간 크기의 변경입니다. 꼼꼼히 확인 부탁드립니다. 📋',
+              'size/L': '큰 변경입니다. 충분한 시간을 두고 리뷰해 주세요. 📦',
+              'size/XL': '매우 큰 변경입니다. PR을 나눌 수 있는지 검토해 주세요. ⚠️',
+              'size/XXL': '🚨 초대형 변경입니다! PR을 여러 개로 분리하는 것을 강력히 권장합니다.'
+            };
+
+            const COMMENT_MARKER = '<!-- pr-size-labeler-bot -->';
+            const commentBody = `${COMMENT_MARKER}\n` +
+                    `### 📏 PR Size: **${sizeLabel}**\n\n` +
+                    `| 항목 | 값 |\n|---|---|\n` +
+                    `| 순수 변경 줄 수 | **${totalChanges}줄** |\n` +
+                    `| 제외된 줄 수 | ${excludedChanges}줄 |\n` +
+                    `| 변경 파일 수 | ${files.length}개 |\n\n` +
+                    `${sizeDescriptions[sizeLabel]}`;
+
+            // 기존 봇 코멘트 찾기
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number
+            });
+            const existingComment = comments.find(c => c.body && c.body.includes(COMMENT_MARKER));
+
+            if (existingComment) {
+              // 기존 코멘트 업데이트
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: commentBody
+              });
+              console.log('기존 코멘트를 업데이트했습니다.');
+            } else {
+              // 새 코멘트 생성
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: commentBody
+              });
+              console.log('새 코멘트를 생성했습니다.');
+            }
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.jpa) apply false
     alias(libs.plugins.spring.boot) apply false
     alias(libs.plugins.dependency.management) apply false
+    alias(libs.plugins.ktlint) apply false
     jacoco
 }
 
@@ -26,6 +27,7 @@ subprojects {
     apply(plugin = "org.jetbrains.kotlin.plugin.spring")
     apply(plugin = "io.spring.dependency-management")
     apply(plugin = "jacoco")
+    apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
     configure<JavaPluginExtension> {
         toolchain {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,12 @@ subprojects {
     apply(plugin = "jacoco")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
+    configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
+        reporters {
+            reporter(org.jlleitschuh.gradle.ktlint.reporter.ReporterType.CHECKSTYLE)
+        }
+    }
+
     configure<JavaPluginExtension> {
         toolchain {
             languageVersion = JavaLanguageVersion.of(21)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,8 @@ spring-boot = "3.2.3"
 dependency-management = "1.1.4"
 springdoc = "2.3.0"
 ktlint = "12.1.2"
+jjwt = "0.12.6"
+bcrypt = "0.10.2"
 
 [libraries]
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
@@ -15,13 +17,20 @@ spring-boot-jpa = { module = "org.springframework.boot:spring-boot-starter-data-
 spring-tx = { module = "org.springframework:spring-tx" }
 spring-context = { module = "org.springframework:spring-context" }
 postgresql = { module = "org.postgresql:postgresql" }
+h2 = { module = "com.h2database:h2" }
 springdoc-openapi = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc" }
+jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }
+jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwt" }
+jjwt-jackson = { module = "io.jsonwebtoken:jjwt-jackson", version.ref = "jjwt" }
+bcrypt = { module = "at.favre.lib:bcrypt", version.ref = "bcrypt" }
+spring-boot-validation = { module = "org.springframework.boot:spring-boot-starter-validation" }
 
 [bundles]
 kotlin = ["kotlin-reflect", "kotlin-stdlib", "jackson-kotlin"]
 spring-application = ["spring-tx", "spring-context"]
 spring-infrastructure = ["spring-boot-jpa"]
 spring-web = ["spring-boot-web"]
+jjwt = ["jjwt-api", "jjwt-impl", "jjwt-jackson"]
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ kotlin = "1.9.24"
 spring-boot = "3.2.3"
 dependency-management = "1.1.4"
 springdoc = "2.3.0"
+ktlint = "12.1.2"
 
 [libraries]
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
@@ -28,3 +29,4 @@ kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotl
 kotlin-jpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin" }
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
 dependency-management = { id = "io.spring.dependency-management", version.ref = "dependency-management" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }

--- a/oop-application/build.gradle.kts
+++ b/oop-application/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
+    "implementation"(project(":oop-common"))
     "implementation"(project(":oop-domain"))
     "implementation"(libs.bundles.spring.application)
 }

--- a/oop-application/src/main/kotlin/com/jaeyong/oop/application/command/LoginCommand.kt
+++ b/oop-application/src/main/kotlin/com/jaeyong/oop/application/command/LoginCommand.kt
@@ -1,0 +1,10 @@
+package com.jaeyong.oop.application.command
+
+/**
+ * 로그인 유스케이스 입력 객체.
+ * presentation의 LoginRequest(DTO)와 분리되어 있다.
+ */
+data class LoginCommand(
+    val email: String,
+    val password: String,
+)

--- a/oop-application/src/main/kotlin/com/jaeyong/oop/application/command/SignupCommand.kt
+++ b/oop-application/src/main/kotlin/com/jaeyong/oop/application/command/SignupCommand.kt
@@ -1,0 +1,13 @@
+package com.jaeyong.oop.application.command
+
+/**
+ * 회원가입 유스케이스 입력 객체.
+ * presentation의 SignupRequest(DTO)와 분리되어 있어서,
+ * HTTP 요청 형식이 바뀌어도 application 레이어는 영향받지 않는다.
+ * 컨트롤러가 DTO → Command 변환을 책임진다.
+ */
+data class SignupCommand(
+    val email: String,
+    val password: String,
+    val nickname: String,
+)

--- a/oop-application/src/main/kotlin/com/jaeyong/oop/application/result/TokenResult.kt
+++ b/oop-application/src/main/kotlin/com/jaeyong/oop/application/result/TokenResult.kt
@@ -1,0 +1,14 @@
+package com.jaeyong.oop.application.result
+
+/**
+ * 로그인/토큰 재발급 유스케이스 출력 객체.
+ * presentation의 TokenResponse(DTO)와 분리되어 있다.
+ * 컨트롤러가 Result → Response 변환을 책임진다.
+ *
+ * - accessToken: API 호출 시 사용 (유효기간 30분)
+ * - refreshToken: Access Token 만료 시 재발급에 사용 (유효기간 14일)
+ */
+data class TokenResult(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/oop-application/src/main/kotlin/com/jaeyong/oop/application/service/AuthService.kt
+++ b/oop-application/src/main/kotlin/com/jaeyong/oop/application/service/AuthService.kt
@@ -1,0 +1,134 @@
+package com.jaeyong.oop.application.service
+
+import com.jaeyong.oop.domain.port.JwtPort
+import com.jaeyong.oop.domain.port.PasswordEncodePort
+import com.jaeyong.oop.domain.port.RefreshTokenPort
+import com.jaeyong.oop.application.command.LoginCommand
+import com.jaeyong.oop.application.command.SignupCommand
+import com.jaeyong.oop.application.result.TokenResult
+import com.jaeyong.oop.application.usecase.AuthUseCase
+import com.jaeyong.oop.application.usecase.TokenValidationUseCase
+import com.jaeyong.oop.common.exception.BaseException
+import com.jaeyong.oop.common.exception.ErrorCode
+import com.jaeyong.oop.domain.member.Member
+import com.jaeyong.oop.domain.member.port.MemberPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 인증 비즈니스 로직을 담당하는 서비스.
+ * AuthUseCase(회원가입/로그인/재발급/로그아웃)와
+ * TokenValidationUseCase(토큰 검증/memberId 추출)를 모두 구현한다.
+ *
+ * 이 서비스는 직접 DB나 JWT를 다루지 않고,
+ * 도메인이 정의한 아웃바운드 포트(MemberPort, JwtPort, PasswordEncodePort, RefreshTokenPort)를
+ * 통해 인프라 레이어에 위임한다.
+ */
+@Service
+class AuthService(
+    private val memberPort: MemberPort,              // 회원 저장소 (→ MemberPersistenceAdapter)
+    private val jwtPort: JwtPort,                    // JWT 생성/검증 (→ JwtAdapter)
+    private val passwordEncodePort: PasswordEncodePort, // 비밀번호 해싱 (→ BcryptAdapter)
+    private val refreshTokenPort: RefreshTokenPort,  // Refresh Token 저장소 (→ RefreshTokenPersistenceAdapter)
+) : AuthUseCase, TokenValidationUseCase {
+
+    /**
+     * 회원가입 처리.
+     * 1. 이메일 중복 검사 → 이미 존재하면 DUPLICATE_EMAIL 예외
+     * 2. 평문 비밀번호를 BCrypt로 해싱
+     * 3. 회원 정보를 DB에 저장
+     */
+    @Transactional
+    override fun signup(command: SignupCommand) {
+        if (memberPort.existsByEmail(command.email)) {
+            throw BaseException(ErrorCode.DUPLICATE_EMAIL)
+        }
+
+        val hashedPassword = passwordEncodePort.encode(command.password)
+        val member =
+            Member(
+                email = command.email,
+                password = hashedPassword,
+                nickname = command.nickname,
+            )
+        memberPort.save(member)
+    }
+
+    /**
+     * 로그인 처리.
+     * 1. 이메일로 회원 조회 → 없으면 LOGIN_FAILED 예외
+     * 2. 비밀번호 검증 → 틀리면 LOGIN_FAILED 예외
+     *    (이메일 없음/비밀번호 틀림을 같은 에러코드로 반환 → 보안상 어떤 정보가 틀렸는지 노출하지 않음)
+     * 3. Access Token(30분) + Refresh Token(14일) 발급
+     * 4. Refresh Token을 해싱하여 DB에 저장 (평문 저장 안 함)
+     */
+    @Transactional
+    override fun login(command: LoginCommand): TokenResult {
+        val member =
+            memberPort.findByEmail(command.email)
+                ?: throw BaseException(ErrorCode.LOGIN_FAILED)
+
+        if (!passwordEncodePort.matches(command.password, member.password)) {
+            throw BaseException(ErrorCode.LOGIN_FAILED)
+        }
+
+        val memberId = member.id!!
+        val accessToken = jwtPort.createAccessToken(memberId)
+        val refreshToken = jwtPort.createRefreshToken(memberId)
+
+        // Refresh Token은 해싱해서 저장 — DB가 유출되어도 토큰 원본을 알 수 없다
+        refreshTokenPort.save(memberId, passwordEncodePort.encode(refreshToken))
+
+        return TokenResult(accessToken, refreshToken)
+    }
+
+    /**
+     * 토큰 재발급 (Refresh Token Rotation 방식).
+     * 1. 전달받은 Refresh Token의 유효성 검증 (만료/변조 체크)
+     * 2. 토큰에서 memberId 추출
+     * 3. DB에 저장된 해싱 Refresh Token과 비교 → 불일치 시 INVALID_TOKEN 예외
+     * 4. 새 Access Token + 새 Refresh Token 발급
+     * 5. 새 Refresh Token을 해싱하여 DB 갱신 (이전 Refresh Token은 더 이상 사용 불가)
+     */
+    @Transactional
+    override fun reissue(refreshToken: String): TokenResult {
+        jwtPort.validateToken(refreshToken)
+
+        val memberId = jwtPort.extractMemberId(refreshToken)
+        val storedHashedToken = refreshTokenPort.findByMemberId(memberId)
+                ?: throw BaseException(ErrorCode.INVALID_TOKEN)
+
+        if (!passwordEncodePort.matches(refreshToken, storedHashedToken)) {
+            throw BaseException(ErrorCode.INVALID_TOKEN)
+        }
+
+        val newAccessToken = jwtPort.createAccessToken(memberId)
+        val newRefreshToken = jwtPort.createRefreshToken(memberId)
+
+        refreshTokenPort.save(memberId, passwordEncodePort.encode(newRefreshToken))
+
+        return TokenResult(newAccessToken, newRefreshToken)
+    }
+
+    /**
+     * 로그아웃 처리.
+     * DB에서 해당 회원의 Refresh Token을 삭제한다.
+     * 이후 클라이언트가 재발급을 요청해도 저장된 토큰이 없으므로 거부된다.
+     * (Access Token은 만료될 때까지 유효하지만, 짧은 수명(30분)으로 리스크를 최소화)
+     */
+    @Transactional
+    override fun logout(memberId: Long) {
+        refreshTokenPort.deleteByMemberId(memberId)
+    }
+
+    // ── TokenValidationUseCase 구현 ──
+    // JwtAuthenticationInterceptor(presentation)가 domain의 JwtPort를 직접 의존하지 않도록
+    // application 레이어에서 중간 다리 역할을 한다.
+    override fun validateToken(token: String) {
+        jwtPort.validateToken(token)
+    }
+
+    override fun extractMemberId(token: String): Long {
+        return jwtPort.extractMemberId(token)
+    }
+}

--- a/oop-application/src/main/kotlin/com/jaeyong/oop/application/service/HealthService.kt
+++ b/oop-application/src/main/kotlin/com/jaeyong/oop/application/service/HealthService.kt
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional
 
 @Service
 class HealthService(
-    private val healthPort: HealthPort
+    private val healthPort: HealthPort,
 ) : HealthCheckUseCase {
     @Transactional
     override fun checkHealth(): String {

--- a/oop-application/src/main/kotlin/com/jaeyong/oop/application/usecase/AuthUseCase.kt
+++ b/oop-application/src/main/kotlin/com/jaeyong/oop/application/usecase/AuthUseCase.kt
@@ -1,0 +1,27 @@
+package com.jaeyong.oop.application.usecase
+
+import com.jaeyong.oop.application.command.LoginCommand
+import com.jaeyong.oop.application.command.SignupCommand
+import com.jaeyong.oop.application.result.TokenResult
+
+/**
+ * 인증 관련 인바운드 포트 (UseCase).
+ * presentation 레이어(AuthController)가 이 인터페이스를 호출하고,
+ * application 레이어(AuthService)가 구현한다.
+ *
+ * 입력은 Command 객체(command 패키지), 출력은 Result 객체(result 패키지)로 분리하여
+ * 행위 계약(UseCase)과 데이터 구조(Command/Result)의 책임을 나눈다.
+ */
+interface AuthUseCase {
+    /** 회원가입: 이메일 중복 검사 → 비밀번호 해싱 → 회원 저장 */
+    fun signup(command: SignupCommand)
+
+    /** 로그인: 이메일/비밀번호 검증 → Access/Refresh Token 발급 → Refresh Token DB 저장 */
+    fun login(command: LoginCommand): TokenResult
+
+    /** 토큰 재발급: Refresh Token 검증 → 새 Access/Refresh Token 발급 (토큰 로테이션) */
+    fun reissue(refreshToken: String): TokenResult
+
+    /** 로그아웃: DB에 저장된 Refresh Token을 삭제하여 재발급을 차단한다. */
+    fun logout(memberId: Long)
+}

--- a/oop-application/src/main/kotlin/com/jaeyong/oop/application/usecase/TokenValidationUseCase.kt
+++ b/oop-application/src/main/kotlin/com/jaeyong/oop/application/usecase/TokenValidationUseCase.kt
@@ -1,0 +1,20 @@
+package com.jaeyong.oop.application.usecase
+
+/**
+ * 토큰 검증 인바운드 포트 (UseCase).
+ * presentation 레이어(JwtAuthenticationInterceptor)가 이 인터페이스를 호출하고,
+ * application 레이어(AuthService)가 구현한다.
+ *
+ * presentation이 domain의 JwtPort를 직접 의존하지 않도록 중간 계층 역할을 한다.
+ * 흐름: Interceptor → TokenValidationUseCase(application) → JwtPort(domain) ← JwtAdapter(infrastructure)
+ */
+interface TokenValidationUseCase {
+    /**
+     * JWT 토큰의 유효성을 검증한다.
+     * 만료 → EXPIRED_TOKEN 예외, 변조/잘못된 형식 → INVALID_TOKEN 예외를 던진다.
+     */
+    fun validateToken(token: String)
+
+    /** JWT 토큰의 subject(payload)에서 회원 ID를 추출한다. */
+    fun extractMemberId(token: String): Long
+}

--- a/oop-application/src/test/kotlin/com/jaeyong/oop/application/service/AuthServiceTest.kt
+++ b/oop-application/src/test/kotlin/com/jaeyong/oop/application/service/AuthServiceTest.kt
@@ -1,0 +1,235 @@
+package com.jaeyong.oop.application.service
+
+import com.jaeyong.oop.domain.port.JwtPort
+import com.jaeyong.oop.domain.port.PasswordEncodePort
+import com.jaeyong.oop.domain.port.RefreshTokenPort
+import com.jaeyong.oop.application.command.LoginCommand
+import com.jaeyong.oop.application.command.SignupCommand
+import com.jaeyong.oop.common.exception.BaseException
+import com.jaeyong.oop.common.exception.ErrorCode
+import com.jaeyong.oop.domain.member.Member
+import com.jaeyong.oop.domain.member.port.MemberPort
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class AuthServiceTest {
+    @Mock
+    private lateinit var memberPort: MemberPort
+
+    @Mock
+    private lateinit var jwtPort: JwtPort
+
+    @Mock
+    private lateinit var passwordEncodePort: PasswordEncodePort
+
+    @Mock
+    private lateinit var refreshTokenPort: RefreshTokenPort
+
+    @InjectMocks
+    private lateinit var authService: AuthService
+
+    private fun <T> anyNonNull(): T {
+        ArgumentMatchers.any<T>()
+        @Suppress("UNCHECKED_CAST")
+        return null as T
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 시 비밀번호를 해싱하여 저장해야 한다")
+    fun `회원가입 성공 시 비밀번호를 해싱하여 저장한다`() {
+        // given
+        val command = SignupCommand("test@example.com", "password1", "닉네임")
+        `when`(memberPort.existsByEmail("test@example.com")).thenReturn(false)
+        `when`(passwordEncodePort.encode("password1")).thenReturn("hashedPassword")
+        `when`(memberPort.save(anyNonNull())).thenReturn(
+            Member(id = 1L, email = "test@example.com", password = "hashedPassword", nickname = "닉네임"),
+        )
+
+        // when
+        authService.signup(command)
+
+        // then
+        verify(passwordEncodePort).encode("password1")
+        verify(memberPort).save(anyNonNull())
+    }
+
+    @Test
+    @DisplayName("이미 가입된 이메일로 회원가입 시 예외가 발생해야 한다")
+    fun `중복된 이메일로 회원가입 시 예외가 발생한다`() {
+        // given
+        val command = SignupCommand("test@example.com", "password1", "닉네임")
+        `when`(memberPort.existsByEmail("test@example.com")).thenReturn(true)
+
+        // when & then
+        assertThatThrownBy { authService.signup(command) }
+            .isInstanceOf(BaseException::class.java)
+            .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_EMAIL)
+    }
+
+    @Test
+    @DisplayName("로그인 성공 시 Access Token과 Refresh Token을 반환해야 한다")
+    fun `로그인 성공 시 토큰을 반환한다`() {
+        // given
+        val command = LoginCommand("test@example.com", "password1")
+        val member = Member(id = 1L, email = "test@example.com", password = "hashedPassword", nickname = "닉네임")
+        `when`(memberPort.findByEmail("test@example.com")).thenReturn(member)
+        `when`(passwordEncodePort.matches("password1", "hashedPassword")).thenReturn(true)
+        `when`(jwtPort.createAccessToken(1L)).thenReturn("access-token")
+        `when`(jwtPort.createRefreshToken(1L)).thenReturn("refresh-token")
+        `when`(passwordEncodePort.encode("refresh-token")).thenReturn("hashed-refresh-token")
+
+        // when
+        val result = authService.login(command)
+
+        // then
+        assertThat(result.accessToken).isEqualTo("access-token")
+        assertThat(result.refreshToken).isEqualTo("refresh-token")
+        verify(refreshTokenPort).save(1L, "hashed-refresh-token")
+    }
+
+    @Test
+    @DisplayName("잘못된 비밀번호로 로그인 시 예외가 발생해야 한다")
+    fun `잘못된 비밀번호로 로그인 시 예외가 발생한다`() {
+        // given
+        val command = LoginCommand("test@example.com", "wrongPassword")
+        val member = Member(id = 1L, email = "test@example.com", password = "hashedPassword", nickname = "닉네임")
+        `when`(memberPort.findByEmail("test@example.com")).thenReturn(member)
+        `when`(passwordEncodePort.matches("wrongPassword", "hashedPassword")).thenReturn(false)
+
+        // when & then
+        assertThatThrownBy { authService.login(command) }
+            .isInstanceOf(BaseException::class.java)
+            .extracting("errorCode").isEqualTo(ErrorCode.LOGIN_FAILED)
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일로 로그인 시 예외가 발생해야 한다")
+    fun `존재하지 않는 이메일로 로그인 시 예외가 발생한다`() {
+        // given
+        val command = LoginCommand("notfound@example.com", "password1")
+        `when`(memberPort.findByEmail("notfound@example.com")).thenReturn(null)
+
+        // when & then
+        assertThatThrownBy { authService.login(command) }
+            .isInstanceOf(BaseException::class.java)
+            .extracting("errorCode").isEqualTo(ErrorCode.LOGIN_FAILED)
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 성공 시 새 Access Token과 Refresh Token을 반환해야 한다")
+    fun `토큰 재발급 성공 시 새 토큰을 반환한다`() {
+        // given
+        val refreshToken = "valid-refresh-token"
+        `when`(jwtPort.extractMemberId(refreshToken)).thenReturn(1L)
+        `when`(refreshTokenPort.findByMemberId(1L)).thenReturn("hashed-refresh-token")
+        `when`(passwordEncodePort.matches(refreshToken, "hashed-refresh-token")).thenReturn(true)
+        `when`(jwtPort.createAccessToken(1L)).thenReturn("new-access-token")
+        `when`(jwtPort.createRefreshToken(1L)).thenReturn("new-refresh-token")
+        `when`(passwordEncodePort.encode("new-refresh-token")).thenReturn("new-hashed-refresh-token")
+
+        // when
+        val result = authService.reissue(refreshToken)
+
+        // then
+        assertThat(result.accessToken).isEqualTo("new-access-token")
+        assertThat(result.refreshToken).isEqualTo("new-refresh-token")
+        verify(refreshTokenPort).save(1L, "new-hashed-refresh-token")
+    }
+
+    @Test
+    @DisplayName("로그아웃 시 Refresh Token이 삭제되어야 한다")
+    fun `로그아웃 시 리프레시 토큰이 삭제된다`() {
+        // given
+        val memberId = 1L
+
+        // when
+        authService.logout(memberId)
+
+        // then
+        verify(refreshTokenPort).deleteByMemberId(memberId)
+    }
+
+    // ── reissue 실패 케이스 ──
+
+    @Test
+    @DisplayName("만료된 Refresh Token으로 재발급 시 예외가 발생해야 한다")
+    fun `만료된 리프레시 토큰으로 재발급 시 예외가 발생한다`() {
+        // given
+        val expiredToken = "expired-refresh-token"
+        `when`(jwtPort.validateToken(expiredToken)).thenThrow(BaseException(ErrorCode.EXPIRED_TOKEN))
+
+        // when & then
+        assertThatThrownBy { authService.reissue(expiredToken) }
+            .isInstanceOf(BaseException::class.java)
+            .extracting("errorCode").isEqualTo(ErrorCode.EXPIRED_TOKEN)
+    }
+
+    @Test
+    @DisplayName("DB에 저장된 Refresh Token이 없으면 예외가 발생해야 한다")
+    fun `저장된 리프레시 토큰이 없으면 예외가 발생한다`() {
+        // given
+        val refreshToken = "valid-refresh-token"
+        `when`(jwtPort.extractMemberId(refreshToken)).thenReturn(1L)
+        `when`(refreshTokenPort.findByMemberId(1L)).thenReturn(null)
+
+        // when & then
+        assertThatThrownBy { authService.reissue(refreshToken) }
+            .isInstanceOf(BaseException::class.java)
+            .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TOKEN)
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 DB의 해시와 불일치하면 예외가 발생해야 한다")
+    fun `리프레시 토큰이 DB 해시와 불일치하면 예외가 발생한다`() {
+        // given
+        val refreshToken = "stolen-refresh-token"
+        `when`(jwtPort.extractMemberId(refreshToken)).thenReturn(1L)
+        `when`(refreshTokenPort.findByMemberId(1L)).thenReturn("hashed-refresh-token")
+        `when`(passwordEncodePort.matches(refreshToken, "hashed-refresh-token")).thenReturn(false)
+
+        // when & then
+        assertThatThrownBy { authService.reissue(refreshToken) }
+            .isInstanceOf(BaseException::class.java)
+            .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TOKEN)
+    }
+
+    // ── TokenValidationUseCase 위임 테스트 ──
+
+    @Test
+    @DisplayName("validateToken은 jwtPort에 위임해야 한다")
+    fun `validateToken은 jwtPort에 위임한다`() {
+        // given
+        val token = "some-token"
+
+        // when
+        authService.validateToken(token)
+
+        // then
+        verify(jwtPort).validateToken(token)
+    }
+
+    @Test
+    @DisplayName("extractMemberId는 jwtPort에 위임하여 memberId를 반환해야 한다")
+    fun `extractMemberId는 jwtPort에 위임하여 memberId를 반환한다`() {
+        // given
+        val token = "some-token"
+        `when`(jwtPort.extractMemberId(token)).thenReturn(1L)
+
+        // when
+        val memberId = authService.extractMemberId(token)
+
+        // then
+        assertThat(memberId).isEqualTo(1L)
+        verify(jwtPort).extractMemberId(token)
+    }
+}

--- a/oop-application/src/test/kotlin/com/jaeyong/oop/application/service/HealthServiceTest.kt
+++ b/oop-application/src/test/kotlin/com/jaeyong/oop/application/service/HealthServiceTest.kt
@@ -9,13 +9,12 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers
 import org.mockito.InjectMocks
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 
 @ExtendWith(MockitoExtension::class)
 class HealthServiceTest {
-
     @Mock
     private lateinit var healthPort: HealthPort
 
@@ -27,8 +26,8 @@ class HealthServiceTest {
     fun `checkHealth should save health and return success`() {
         // given
         val health = Health(status = "OK")
-        
-        // 이론적 해결책: Mockito.any()가 null을 반환하여 발생하는 NPE를 피하기 위해 
+
+        // 이론적 해결책: Mockito.any()가 null을 반환하여 발생하는 NPE를 피하기 위해
         // 헬퍼 함수 anyNonNull()을 사용합니다.
         `when`(healthPort.save(anyNonNull())).thenReturn(health)
 

--- a/oop-boot/src/main/kotlin/com/jaeyong/oop/BootApplication.kt
+++ b/oop-boot/src/main/kotlin/com/jaeyong/oop/BootApplication.kt
@@ -6,7 +6,7 @@ import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 
 @SpringBootApplication(
-    scanBasePackages = ["com.jaeyong.oop"]
+    scanBasePackages = ["com.jaeyong.oop"],
 )
 @EnableJpaRepositories(basePackages = ["com.jaeyong.oop"])
 @EntityScan(basePackages = ["com.jaeyong.oop"])

--- a/oop-boot/src/main/kotlin/com/jaeyong/oop/boot/config/SwaggerConfig.kt
+++ b/oop-boot/src/main/kotlin/com/jaeyong/oop/boot/config/SwaggerConfig.kt
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class SwaggerConfig {
-
     @Bean
     fun openAPI(): OpenAPI {
         return OpenAPI()
@@ -15,7 +14,7 @@ class SwaggerConfig {
                 Info()
                     .title("OOP Project API")
                     .description("객체 지향 프로그래밍 프로젝트 API 문서")
-                    .version("1.0.0")
+                    .version("1.0.0"),
             )
     }
 }

--- a/oop-boot/src/main/kotlin/com/jaeyong/oop/boot/config/WebConfig.kt
+++ b/oop-boot/src/main/kotlin/com/jaeyong/oop/boot/config/WebConfig.kt
@@ -1,29 +1,64 @@
 package com.jaeyong.oop.boot.config
 
+import com.jaeyong.oop.presentation.auth.interceptor.CurrentMemberArgumentResolver
+import com.jaeyong.oop.presentation.auth.interceptor.JwtAuthenticationInterceptor
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
+// Spring MVC의 웹 관련 설정을 담당하는 클래스
+// CORS, 인터셉터(인증 관문), ArgumentResolver(@CurrentMember) 3가지를 설정한다.
 @Configuration
 class WebConfig(
-    @Value("\${cors.allowed-origins}") private val allowedOrigins: Array<String>
+    @Value("\${cors.allowed-origins}") private val allowedOrigins: Array<String>, // application.yml에서 허용할 출처 목록을 읽어온다
+    private val jwtAuthenticationInterceptor: JwtAuthenticationInterceptor,       // JWT 토큰 검증 인터셉터
+    private val currentMemberArgumentResolver: CurrentMemberArgumentResolver,     // @CurrentMember 파라미터에 회원 ID를 주입하는 리졸버
 ) : WebMvcConfigurer {
 
+    // ── CORS 설정 ──
+    // 다른 도메인(예: localhost:3000 프론트엔드)에서 이 API를 호출할 수 있도록 허용한다.
+    // 이 설정이 없으면 브라우저가 요청을 차단한다. (Postman/curl은 영향 없음)
     override fun addCorsMappings(registry: CorsRegistry) {
-        registry.addMapping("/**")
-            .allowedOrigins(*allowedOrigins) // 가변 인자로 펼쳐서 전달
-            .allowedMethods(
+        registry.addMapping("/**")                // 모든 경로에 대해 CORS 적용
+            .allowedOrigins(*allowedOrigins)       // 허용할 출처 (localhost:3000, localhost:8080 등)
+            .allowedMethods(                       // 허용할 HTTP 메서드
                 HttpMethod.GET.name(),
                 HttpMethod.POST.name(),
                 HttpMethod.PUT.name(),
                 HttpMethod.DELETE.name(),
                 HttpMethod.PATCH.name(),
-                HttpMethod.OPTIONS.name()
+                HttpMethod.OPTIONS.name(),
             )
-            .allowedHeaders("*")
-            .allowCredentials(true)
-            .maxAge(3600)
+            .allowedHeaders("*")                   // 모든 요청 헤더 허용
+            .allowCredentials(true)                 // 쿠키/인증정보 포함 허용
+            .maxAge(3600)                           // 브라우저가 CORS 결과를 1시간 동안 캐싱 (매번 확인 안 해도 됨)
+    }
+
+    // ── 인터셉터 설정 ──
+    // 모든 /api/** 요청 전에 JWT 토큰을 검사하는 관문을 세운다.
+    // 비유: 건물 입구에 출입카드 리더기를 설치하되, 로비(로그인/회원가입 등)는 카드 없이 통과 가능.
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(jwtAuthenticationInterceptor)
+            .addPathPatterns("/api/**")            // /api/로 시작하는 모든 요청에 JWT 검사 적용
+            .excludePathPatterns(                  // 아래 경로는 토큰 없이 접근 가능 (인증 제외)
+                "/api/v1/auth/signup",             // 회원가입 — 토큰이 아직 없는 사용자
+                "/api/v1/auth/login",              // 로그인 — 토큰을 받으려는 사용자
+                "/api/v1/auth/reissue",            // 토큰 재발급 — Access Token이 만료된 상태
+                "/api/health/**",                  // 헬스체크 — 서버 상태 확인용
+                "/swagger-ui/**",                  // Swagger UI 페이지
+                "/v3/api-docs/**",                 // Swagger API 문서 데이터
+            )
+    }
+
+    // ── ArgumentResolver 설정 ──
+    // 컨트롤러에서 @CurrentMember memberId: Long 파라미터를 사용하면
+    // 인터셉터가 토큰에서 꺼낸 회원 ID가 자동으로 주입된다.
+    // 인터셉터(토큰 검증 → memberId 추출) → ArgumentResolver(memberId를 파라미터에 전달) 순으로 동작한다.
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(currentMemberArgumentResolver)
     }
 }

--- a/oop-boot/src/main/resources/application-local.yml
+++ b/oop-boot/src/main/resources/application-local.yml
@@ -15,3 +15,8 @@ spring:
 
 cors:
   allowed-origins: "http://localhost:3000,http://localhost:8080"
+
+jwt:
+  secret: local-test-secret-key-must-be-at-least-256-bits-long-for-hs256
+  access-token-expiry: 1800000
+  refresh-token-expiry: 1209600000

--- a/oop-boot/src/test/kotlin/com/jaeyong/oop/BootApplicationTests.kt
+++ b/oop-boot/src/test/kotlin/com/jaeyong/oop/BootApplicationTests.kt
@@ -5,7 +5,6 @@ import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 class BootApplicationTests {
-
     @Test
     fun contextLoads() {
     }

--- a/oop-common/src/main/kotlin/com/jaeyong/oop/common/exception/BaseException.kt
+++ b/oop-common/src/main/kotlin/com/jaeyong/oop/common/exception/BaseException.kt
@@ -8,5 +8,5 @@ package com.jaeyong.oop.common.exception
  */
 open class BaseException(
     val errorCode: ErrorCode,
-    cause: Throwable? = null
+    cause: Throwable? = null,
 ) : RuntimeException(errorCode.code, cause)

--- a/oop-common/src/main/kotlin/com/jaeyong/oop/common/exception/ErrorCode.kt
+++ b/oop-common/src/main/kotlin/com/jaeyong/oop/common/exception/ErrorCode.kt
@@ -10,7 +10,7 @@ package com.jaeyong.oop.common.exception
  *   S-XXX : 시스템 에러
  */
 enum class ErrorCode(
-    val code: String
+    val code: String,
 ) {
     // ── 도메인 비즈니스 에러 (D-XXX) ──
     NOT_FOUND("D001"),
@@ -21,6 +21,10 @@ enum class ErrorCode(
     // ── 애플리케이션 에러 (A-XXX) ──
     UNAUTHORIZED("A001"),
     EXTERNAL_SERVICE_FAIL("A002"),
+    LOGIN_FAILED("A003"),
+    INVALID_TOKEN("A004"),
+    EXPIRED_TOKEN("A005"),
+    DUPLICATE_EMAIL("A006"),
 
     // ── 공통 에러 (C-XXX) ──
     VALIDATION_ERROR("C001"),

--- a/oop-common/src/test/kotlin/com/jaeyong/oop/common/exception/BaseExceptionTest.kt
+++ b/oop-common/src/test/kotlin/com/jaeyong/oop/common/exception/BaseExceptionTest.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 class BaseExceptionTest {
-
     @Test
     @DisplayName("BaseException 생성 시 설정한 ErrorCode와 메시지가 올바르게 저장되어야 한다")
     fun `should have correct error code when created`() {

--- a/oop-domain/src/main/kotlin/com/jaeyong/oop/domain/health/Health.kt
+++ b/oop-domain/src/main/kotlin/com/jaeyong/oop/domain/health/Health.kt
@@ -8,5 +8,5 @@ import java.time.LocalDateTime
 data class Health(
     val id: Long? = null,
     val status: String,
-    val createdAt: LocalDateTime = LocalDateTime.now()
+    val createdAt: LocalDateTime = LocalDateTime.now(),
 )

--- a/oop-domain/src/main/kotlin/com/jaeyong/oop/domain/member/Member.kt
+++ b/oop-domain/src/main/kotlin/com/jaeyong/oop/domain/member/Member.kt
@@ -1,0 +1,14 @@
+package com.jaeyong.oop.domain.member
+
+/**
+ * 회원 도메인 모델.
+ * 순수 Kotlin 클래스로, JPA/Spring 등 프레임워크에 의존하지 않는다.
+ * DB 저장 전에는 id가 null이고, 저장 후 자동 생성된 값이 채워진다.
+ * password는 항상 해싱된 상태로 저장된다 (평문이 들어오는 일 없음).
+ */
+data class Member(
+    val id: Long? = null,
+    val email: String,
+    val password: String,
+    val nickname: String,
+)

--- a/oop-domain/src/main/kotlin/com/jaeyong/oop/domain/member/port/MemberPort.kt
+++ b/oop-domain/src/main/kotlin/com/jaeyong/oop/domain/member/port/MemberPort.kt
@@ -1,0 +1,19 @@
+package com.jaeyong.oop.domain.member.port
+
+import com.jaeyong.oop.domain.member.Member
+
+/**
+ * 회원 저장소 아웃바운드 포트.
+ * 도메인이 정의하고, infrastructure의 MemberPersistenceAdapter가 구현한다.
+ * application 레이어(AuthService)가 이 포트를 통해 회원 데이터에 접근한다.
+ */
+interface MemberPort {
+    /** 회원을 저장하고, 자동 생성된 id가 채워진 Member를 반환한다. */
+    fun save(member: Member): Member
+
+    /** 이메일로 회원을 조회한다. 없으면 null. */
+    fun findByEmail(email: String): Member?
+
+    /** 해당 이메일이 이미 등록되어 있는지 확인한다. 회원가입 시 중복 검사에 사용. */
+    fun existsByEmail(email: String): Boolean
+}

--- a/oop-domain/src/main/kotlin/com/jaeyong/oop/domain/port/JwtPort.kt
+++ b/oop-domain/src/main/kotlin/com/jaeyong/oop/domain/port/JwtPort.kt
@@ -1,0 +1,16 @@
+package com.jaeyong.oop.domain.port
+
+/**
+ * JWT 토큰 생성/검증 포트
+ *
+ * validateToken은 토큰이 유효하면 true, 만료되면 EXPIRED_TOKEN 예외, 변조/잘못된 형식이면 INVALID_TOKEN 예외를 던진다.
+ */
+interface JwtPort {
+    fun createAccessToken(memberId: Long): String
+
+    fun createRefreshToken(memberId: Long): String
+
+    fun extractMemberId(token: String): Long
+
+    fun validateToken(token: String)
+}

--- a/oop-domain/src/main/kotlin/com/jaeyong/oop/domain/port/PasswordEncodePort.kt
+++ b/oop-domain/src/main/kotlin/com/jaeyong/oop/domain/port/PasswordEncodePort.kt
@@ -1,0 +1,18 @@
+package com.jaeyong.oop.domain.port
+
+/**
+ * 비밀번호 해싱/검증 아웃바운드 포트.
+ * 도메인이 정의하고, infrastructure의 BcryptAdapter가 구현한다.
+ * 비밀번호 저장 시 encode(), 로그인 시 matches()를 사용한다.
+ */
+interface PasswordEncodePort {
+    /** 평문 비밀번호를 해싱한다. 회원가입 시 DB에 저장하기 전 호출.
+     * 비밀번호 해싱은 핵심 비즈니스 로직이 아님 -> 기술 (비번 해싱 기술이 언제든지 바뀔 있음)
+     * 핵심 비즈니스 로직: 비밀번호를 안전하게 저장해야 한다*/
+    fun encode(rawPassword: String): String
+
+    /** 평문 비밀번호가 해싱된 비밀번호와 일치하는지 검증한다. 로그인 시 호출.
+     * 해싱된 비밀번호 인증은 핵심 비즈니스 로직이 아님 -> 기술
+     * 핵심 비즈니스 로직: 로그인시 비밀번호가 일치해야 한다.*/
+    fun matches(rawPassword: String, encodedPassword: String, ): Boolean
+}

--- a/oop-domain/src/main/kotlin/com/jaeyong/oop/domain/port/RefreshTokenPort.kt
+++ b/oop-domain/src/main/kotlin/com/jaeyong/oop/domain/port/RefreshTokenPort.kt
@@ -1,0 +1,20 @@
+package com.jaeyong.oop.domain.port
+
+/**
+ * Refresh Token 저장소 아웃바운드 포트.
+ * 도메인이 정의하고, infrastructure의 RefreshTokenPersistenceAdapter가 구현한다.
+ * Refresh Token은 항상 해싱된 상태로 저장된다 (평문 저장 안 함).
+ */
+interface RefreshTokenPort {
+    /**
+     * 회원의 Refresh Token(해싱됨)을 저장한다.
+     * 이미 존재하면 갱신, 없으면 새로 생성한다. (토큰 로테이션)
+     */
+    fun save(memberId: Long, hashedToken: String, )
+
+    /** 회원의 저장된 해싱 Refresh Token을 조회한다. 없으면 null. */
+    fun findByMemberId(memberId: Long): String?
+
+    /** 회원의 Refresh Token을 삭제한다. 로그아웃 시 호출. */
+    fun deleteByMemberId(memberId: Long)
+}

--- a/oop-domain/src/test/kotlin/com/jaeyong/oop/domain/health/HealthTest.kt
+++ b/oop-domain/src/test/kotlin/com/jaeyong/oop/domain/health/HealthTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
 class HealthTest {
-
     @Test
     @DisplayName("Health 도메인 객체를 생성할 때 기본값이 올바르게 설정되어야 한다")
     fun `should create health entity with default values`() {

--- a/oop-domain/src/test/kotlin/com/jaeyong/oop/domain/member/MemberTest.kt
+++ b/oop-domain/src/test/kotlin/com/jaeyong/oop/domain/member/MemberTest.kt
@@ -1,0 +1,35 @@
+package com.jaeyong.oop.domain.member
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class MemberTest {
+    @Test
+    @DisplayName("Member 도메인 객체를 생성할 때 기본값이 올바르게 설정되어야 한다")
+    fun `기본값으로 Member 객체를 생성할 수 있다`() {
+        // given
+        val email = "test@example.com"
+        val password = "hashedPassword"
+        val nickname = "테스트"
+
+        // when
+        val member = Member(email = email, password = password, nickname = nickname)
+
+        // then
+        assertThat(member.id).isNull()
+        assertThat(member.email).isEqualTo(email)
+        assertThat(member.password).isEqualTo(password)
+        assertThat(member.nickname).isEqualTo(nickname)
+    }
+
+    @Test
+    @DisplayName("Member 객체의 모든 필드를 지정하여 생성할 수 있어야 한다 (반환할때 ID 채워서 반환 해줘야함)")
+    fun `모든 필드를 지정하여 Member 객체를 생성할 수 있다`() {
+        // given & when
+        val member = Member(id = 1L, email = "test@example.com", password = "hashed", nickname = "닉네임")
+
+        // then
+        assertThat(member.id).isEqualTo(1L)
+    }
+}

--- a/oop-infrastructure/build.gradle.kts
+++ b/oop-infrastructure/build.gradle.kts
@@ -3,7 +3,11 @@ plugins {
 }
 
 dependencies {
+    "implementation"(project(":oop-common"))
     "implementation"(project(":oop-domain"))
     "implementation"(libs.bundles.spring.infrastructure)
+    "implementation"(libs.bundles.jjwt)
+    "implementation"(libs.bcrypt)
     "runtimeOnly"(libs.postgresql)
+    "testRuntimeOnly"(libs.h2)
 }

--- a/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/HealthEntity.kt
+++ b/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/HealthEntity.kt
@@ -1,7 +1,12 @@
 package com.jaeyong.oop.infrastructure.persistence
 
 import com.jaeyong.oop.domain.health.Health
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
 import java.time.LocalDateTime
 
 /**
@@ -12,18 +17,15 @@ import java.time.LocalDateTime
 class HealthEntity(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null,
-
     @Column(name = "status", nullable = false, length = 50)
     val status: String,
-
     @Column(name = "created_at", nullable = false)
-    val createdAt: LocalDateTime
+    val createdAt: LocalDateTime,
 ) {
     // 도메인 모델 <-> DB 엔티티 변환 메서드
     fun toDomain(): Health = Health(id, status, createdAt)
-    
+
     companion object {
-        fun fromDomain(health: Health): HealthEntity = 
-            HealthEntity(health.id, health.status, health.createdAt)
+        fun fromDomain(health: Health): HealthEntity = HealthEntity(health.id, health.status, health.createdAt)
     }
 }

--- a/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/HealthPersistenceAdapter.kt
+++ b/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/HealthPersistenceAdapter.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository
  */
 @Repository
 class HealthPersistenceAdapter(
-    private val healthJpaRepository: HealthJpaRepository
+    private val healthJpaRepository: HealthJpaRepository,
 ) : HealthPort {
     override fun save(health: Health): Health {
         val entity = HealthEntity.fromDomain(health)

--- a/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/member/MemberEntity.kt
+++ b/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/member/MemberEntity.kt
@@ -1,0 +1,38 @@
+package com.jaeyong.oop.infrastructure.persistence.member
+
+import com.jaeyong.oop.domain.member.Member
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+/**
+ * 회원 JPA 엔티티.
+ * DB의 members 테이블과 매핑된다.
+ *
+ * 도메인 모델(Member)과 JPA 엔티티를 분리하여
+ * 도메인이 JPA에 의존하지 않도록 한다 (헥사고날 아키텍처).
+ * toDomain() / fromDomain()으로 상호 변환한다.
+ */
+@Entity
+@Table(name = "members")
+class MemberEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    @Column(nullable = false, unique = true) // 이메일 중복 방지 (DB 레벨 유니크 제약)
+    val email: String,
+    @Column(nullable = false) // 해싱된 비밀번호가 저장됨
+    val password: String,
+    @Column(nullable = false, length = 20)
+    val nickname: String,
+) {
+    /** JPA 엔티티 → 도메인 모델 변환 */
+    fun toDomain(): Member = Member(id, email, password, nickname)
+
+    companion object {
+        /** 도메인 모델 → JPA 엔티티 변환 */
+        fun fromDomain(member: Member): MemberEntity = MemberEntity(member.id, member.email, member.password, member.nickname)
+    }
+}

--- a/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/member/MemberJpaRepository.kt
+++ b/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/member/MemberJpaRepository.kt
@@ -1,0 +1,14 @@
+package com.jaeyong.oop.infrastructure.persistence.member
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+/**
+ * 회원 JPA Repository.
+// * Spring Data JPA가 인터페이스 -> 메서드 이름을 분석하여 자동으로 쿼리를 생성한다.
+ * MemberPersistenceAdapter에서만 사용되며, 외부 레이어에 직접 노출되지 않는다.
+ */
+interface MemberJpaRepository : JpaRepository<MemberEntity, Long> {
+    fun findByEmail(email: String): MemberEntity?
+
+    fun existsByEmail(email: String): Boolean
+}

--- a/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/member/MemberPersistenceAdapter.kt
+++ b/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/member/MemberPersistenceAdapter.kt
@@ -1,0 +1,27 @@
+package com.jaeyong.oop.infrastructure.persistence.member
+
+import com.jaeyong.oop.domain.member.Member
+import com.jaeyong.oop.domain.member.port.MemberPort
+import org.springframework.stereotype.Repository
+
+/**
+ * MemberPort의 구현체 (아웃바운드 어댑터).
+ * 도메인 모델(Member) ↔ JPA 엔티티(MemberEntity) 변환을 처리하고,
+ * Spring Data JPA를 통해 실제 DB 작업을 수행한다.
+ */
+@Repository
+class MemberPersistenceAdapter(private val memberJpaRepository: MemberJpaRepository, ) : MemberPort {
+
+    override fun save(member: Member): Member {
+        val entity = MemberEntity.fromDomain(member) // 도메인 → 엔티티 변환
+        return memberJpaRepository.save(entity).toDomain() // 저장 후 엔티티 → 도메인 변환 (id 채워짐)
+    }
+
+    override fun findByEmail(email: String): Member? {
+        return memberJpaRepository.findByEmail(email)?.toDomain()
+    }
+
+    override fun existsByEmail(email: String): Boolean {
+        return memberJpaRepository.existsByEmail(email)
+    }
+}

--- a/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/token/RefreshTokenEntity.kt
+++ b/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/token/RefreshTokenEntity.kt
@@ -1,0 +1,32 @@
+package com.jaeyong.oop.infrastructure.persistence.token
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+/**
+ * Refresh Token JPA 엔티티.
+ * DB의 refresh_tokens 테이블과 매핑된다.
+ *
+ * 회원당 하나의 Refresh Token만 유지된다 (memberId에 unique 제약).
+ * hashedToken에는 BCrypt로 해싱된 토큰이 저장된다 (평문 아님).
+ * 토큰 재발급(rotation) 시 updateHashedToken()으로 기존 레코드를 갱신한다.
+ */
+@Entity
+@Table(name = "refresh_tokens")
+class RefreshTokenEntity(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    @Column(nullable = false, unique = true) // 회원당 1개의 Refresh Token만 허용
+    val memberId: Long,
+    @Column(nullable = false) // BCrypt로 해싱된 Refresh Token
+    var hashedToken: String,
+) {
+    /** 토큰 로테이션 시 해싱된 새 토큰으로 갱신한다. */
+    fun updateHashedToken(newHashedToken: String) {
+        this.hashedToken = newHashedToken
+    }
+}

--- a/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/token/RefreshTokenJpaRepository.kt
+++ b/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/token/RefreshTokenJpaRepository.kt
@@ -1,0 +1,10 @@
+package com.jaeyong.oop.infrastructure.persistence.token
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+/** Refresh Token JPA Repository. RefreshTokenPersistenceAdapter에서만 사용된다. */
+interface RefreshTokenJpaRepository : JpaRepository<RefreshTokenEntity, Long> {
+    fun findByMemberId(memberId: Long): RefreshTokenEntity?
+
+    fun deleteByMemberId(memberId: Long)
+}

--- a/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/token/RefreshTokenPersistenceAdapter.kt
+++ b/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/persistence/token/RefreshTokenPersistenceAdapter.kt
@@ -1,0 +1,33 @@
+package com.jaeyong.oop.infrastructure.persistence.token
+
+import com.jaeyong.oop.domain.port.RefreshTokenPort
+import org.springframework.stereotype.Repository
+
+/**
+ * RefreshTokenPort의 구현체 (아웃바운드 어댑터).
+ * Refresh Token의 CRUD를 JPA를 통해 처리한다.
+ */
+@Repository
+class RefreshTokenPersistenceAdapter(private val refreshTokenJpaRepository: RefreshTokenJpaRepository, ) : RefreshTokenPort {
+    /**
+     * Refresh Token 저장 (Upsert 방식).
+     * 해당 회원의 토큰이 이미 있으면 갱신, 없으면 새로 생성한다.
+     * 이렇게 하면 회원당 항상 1개의 Refresh Token만 유지된다.
+     */
+    override fun save(memberId: Long, hashedToken: String, ) {
+        val existing = refreshTokenJpaRepository.findByMemberId(memberId)
+        if (existing != null) {
+            existing.updateHashedToken(hashedToken) // 더티 체킹으로 UPDATE 쿼리 발생 (리프레시 토큰 업데이트)
+        } else {
+            refreshTokenJpaRepository.save(RefreshTokenEntity(memberId = memberId, hashedToken = hashedToken))
+        }
+    }
+
+    override fun findByMemberId(memberId: Long): String? {
+        return refreshTokenJpaRepository.findByMemberId(memberId)?.hashedToken
+    }
+
+    override fun deleteByMemberId(memberId: Long) {
+        refreshTokenJpaRepository.deleteByMemberId(memberId)
+    }
+}

--- a/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/security/BcryptAdapter.kt
+++ b/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/security/BcryptAdapter.kt
@@ -1,0 +1,26 @@
+package com.jaeyong.oop.infrastructure.security
+
+import at.favre.lib.crypto.bcrypt.BCrypt
+import com.jaeyong.oop.domain.port.PasswordEncodePort
+import org.springframework.stereotype.Component
+
+/**
+ * PasswordEncodePort의 구현체 (아웃바운드 어댑터).
+ * BCrypt 알고리즘으로 비밀번호를 해싱하고 검증한다.
+ * cost factor 12: 해싱에 약 250ms 소요 — 보안성과 성능의 균형점.
+ *
+ * 비밀번호뿐 아니라 Refresh Token 해싱에도 사용된다.
+ */
+@Component
+class BcryptAdapter : PasswordEncodePort {
+
+    /** 평문을 BCrypt로 해싱한다. 매 호출마다 랜덤 salt가 생성되어 같은 입력도 다른 해시값을 반환한다. */
+    override fun encode(rawPassword: String): String {
+        return BCrypt.withDefaults().hashToString(12, rawPassword.toCharArray())
+    }
+
+    /** 평문이 해싱된 값과 일치하는지 검증한다. */
+    override fun matches(rawPassword: String, encodedPassword: String, ): Boolean {
+        return BCrypt.verifyer().verify(rawPassword.toCharArray(), encodedPassword).verified
+    }
+}

--- a/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/security/JwtAdapter.kt
+++ b/oop-infrastructure/src/main/kotlin/com/jaeyong/oop/infrastructure/security/JwtAdapter.kt
@@ -1,0 +1,84 @@
+package com.jaeyong.oop.infrastructure.security
+
+import com.jaeyong.oop.domain.port.JwtPort
+import com.jaeyong.oop.common.exception.BaseException
+import com.jaeyong.oop.common.exception.ErrorCode
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.util.Date
+import javax.crypto.SecretKey
+
+/**
+ * JwtPort의 구현체 (아웃바운드 어댑터).
+ * JJWT 라이브러리를 사용하여 JWT 토큰을 생성, 검증, 파싱한다.
+ *
+ * 설정값은 application.yml에서 주입:
+ * - jwt.secret: 서명에 사용하는 비밀키 (HS256, 최소 256비트)
+ * - jwt.access-token-expiry: Access Token 유효기간 (밀리초, 기본 30분 = 1800000)
+ * - jwt.refresh-token-expiry: Refresh Token 유효기간 (밀리초, 기본 14일 = 1209600000)
+ *
+ * 토큰 payload에는 subject(memberId)만 포함 — 이메일 등 개인정보를 넣지 않는다.
+ */
+@Component
+class JwtAdapter(
+    @Value("\${jwt.secret}") private val secret: String,
+    @Value("\${jwt.access-token-expiry}") private val accessTokenExpiry: Long,
+    @Value("\${jwt.refresh-token-expiry}") private val refreshTokenExpiry: Long,
+) : JwtPort {
+
+    // lazy 초기화: 첫 사용 시점에 secret 문자열 → HMAC-SHA 키 객체로 변환
+    private val key: SecretKey by lazy {
+        Keys.hmacShaKeyFor(secret.toByteArray())
+    }
+
+    override fun createAccessToken(memberId: Long): String {
+        return createToken(memberId, accessTokenExpiry)
+    }
+
+    override fun createRefreshToken(memberId: Long): String {
+        return createToken(memberId, refreshTokenExpiry)
+    }
+
+    /** 토큰의 subject 클레임에서 memberId를 추출한다. */
+    override fun extractMemberId(token: String): Long {
+        val claims =
+            Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .payload
+        return claims.subject.toLong()
+    }
+
+    /**
+     * 토큰 유효성 검증.
+     * - 만료된 토큰 → EXPIRED_TOKEN 예외 (클라이언트가 reissue 요청해야 함)
+     * - 변조/잘못된 형식 → INVALID_TOKEN 예외
+     */
+    override fun validateToken(token: String) {
+        try {
+            Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+        } catch (e: ExpiredJwtException) {
+            throw BaseException(ErrorCode.EXPIRED_TOKEN)
+        } catch (e: Exception) {
+            throw BaseException(ErrorCode.INVALID_TOKEN)
+        }
+    }
+
+    /** JWT 토큰 생성 공통 로직. subject에 memberId, 발행시간, 만료시간을 설정하고 서명한다. */
+    private fun createToken(memberId: Long, expiry: Long, ): String {
+        val now = Date()
+        return Jwts.builder()
+            .subject(memberId.toString()) // payload에 memberId만 포함 (개인정보 없음)
+            .issuedAt(now)
+            .expiration(Date(now.time + expiry))
+            .signWith(key) // HS256 서명
+            .compact()
+    }
+}

--- a/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/TestConfig.kt
+++ b/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/TestConfig.kt
@@ -1,0 +1,6 @@
+package com.jaeyong.oop.infrastructure
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+
+@SpringBootApplication
+class TestConfig

--- a/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/persistence/HealthEntityTest.kt
+++ b/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/persistence/HealthEntityTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
 class HealthEntityTest {
-
     @Test
     @DisplayName("1 & 2. 생성자 및 Getter 검증: 모든 필드가 정상적으로 초기화되고 값을 반환해야 한다")
     fun `constructor and getter validation`() {
@@ -92,7 +91,7 @@ class HealthEntityTest {
         // then
         assertThat(entity.id).isNull()
         assertThat(entity.status).isEqualTo(status)
-        
+
         // domain 변환 시에도 id가 null로 유지되는지 확인
         val domain = entity.toDomain()
         assertThat(domain.id).isNull()

--- a/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/persistence/HealthPersistenceAdapterTest.kt
+++ b/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/persistence/HealthPersistenceAdapterTest.kt
@@ -5,16 +5,15 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers.any
 import org.mockito.BDDMockito.given
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.ArgumentMatchers.any
 import java.time.LocalDateTime
 
 @ExtendWith(MockitoExtension::class)
 class HealthPersistenceAdapterTest {
-
     @Mock
     private lateinit var healthJpaRepository: HealthJpaRepository
 

--- a/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/persistence/member/MemberEntityTest.kt
+++ b/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/persistence/member/MemberEntityTest.kt
@@ -1,0 +1,69 @@
+package com.jaeyong.oop.infrastructure.persistence.member
+
+import com.jaeyong.oop.domain.member.Member
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class MemberEntityTest {
+    @Test
+    @DisplayName("도메인 Member를 MemberEntity로 변환할 수 있어야 한다")
+    fun `도메인 Member를 MemberEntity로 변환할 수 있다`() {
+        // given
+        val member = Member(email = "test@example.com", password = "hashed", nickname = "닉네임")
+
+        // when
+        val entity = MemberEntity.fromDomain(member)
+
+        // then
+        assertThat(entity.email).isEqualTo("test@example.com")
+        assertThat(entity.password).isEqualTo("hashed")
+        assertThat(entity.nickname).isEqualTo("닉네임")
+    }
+
+    @Test
+    @DisplayName("id가 있는 도메인 Member를 MemberEntity로 변환하면 id가 유지되어야 한다")
+    fun `id가 있는 도메인 Member를 MemberEntity로 변환하면 id가 유지된다`() {
+        // given
+        val member = Member(id = 1L, email = "test@example.com", password = "hashed", nickname = "닉네임")
+
+        // when
+        val entity = MemberEntity.fromDomain(member)
+
+        // then
+        assertThat(entity.id).isEqualTo(1L)
+        assertThat(entity.email).isEqualTo("test@example.com")
+        assertThat(entity.password).isEqualTo("hashed")
+        assertThat(entity.nickname).isEqualTo("닉네임")
+    }
+
+    @Test
+    @DisplayName("MemberEntity를 도메인 Member로 변환할 수 있어야 한다")
+    fun `MemberEntity를 도메인 Member로 변환할 수 있다`() {
+        // given
+        val entity = MemberEntity(id = 1L, email = "test@example.com", password = "hashed", nickname = "닉네임")
+
+        // when
+        val member = entity.toDomain()
+
+        // then
+        assertThat(member.id).isEqualTo(1L)
+        assertThat(member.email).isEqualTo("test@example.com")
+        assertThat(member.password).isEqualTo("hashed")
+        assertThat(member.nickname).isEqualTo("닉네임")
+    }
+
+    @Test
+    @DisplayName("id가 없는 MemberEntity를 도메인 Member로 변환하면 id가 null이어야 한다")
+    fun `id가 없는 MemberEntity를 도메인 Member로 변환하면 id가 null이다`() {
+        // given
+        val entity = MemberEntity(email = "test@example.com", password = "hashed", nickname = "닉네임")
+
+        // when
+        val member = entity.toDomain()
+
+        // then
+        assertThat(member.id).isNull()
+        assertThat(member.email).isEqualTo("test@example.com")
+    }
+}

--- a/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/persistence/member/MemberPersistenceAdapterTest.kt
+++ b/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/persistence/member/MemberPersistenceAdapterTest.kt
@@ -1,0 +1,75 @@
+package com.jaeyong.oop.infrastructure.persistence.member
+
+import com.jaeyong.oop.domain.member.Member
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(MemberPersistenceAdapter::class)
+class MemberPersistenceAdapterTest {
+    @Autowired
+    private lateinit var adapter: MemberPersistenceAdapter
+
+    @Test
+    @DisplayName("회원을 저장하면 id가 자동 생성되어야 한다")
+    fun `회원을 저장하면 id가 자동 생성된다`() {
+        // given
+        val member = Member(email = "test@example.com", password = "hashed", nickname = "닉네임")
+
+        // when
+        val saved = adapter.save(member)
+
+        // then
+        assertThat(saved.id).isNotNull()
+        assertThat(saved.email).isEqualTo("test@example.com")
+        assertThat(saved.password).isEqualTo("hashed")
+        assertThat(saved.nickname).isEqualTo("닉네임")
+    }
+
+    @Test
+    @DisplayName("이메일로 회원을 조회할 수 있어야 한다")
+    fun `이메일로 회원을 조회할 수 있다`() {
+        // given
+        adapter.save(Member(email = "test@example.com", password = "hashed", nickname = "닉네임"))
+
+        // when
+        val found = adapter.findByEmail("test@example.com")
+
+        // then
+        assertThat(found).isNotNull
+        assertThat(found!!.email).isEqualTo("test@example.com")
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일로 조회하면 null을 반환해야 한다")
+    fun `존재하지 않는 이메일로 조회하면 null을 반환한다`() {
+        // when
+        val found = adapter.findByEmail("notfound@example.com")
+
+        // then
+        assertThat(found).isNull()
+    }
+
+    @Test
+    @DisplayName("이미 등록된 이메일은 existsByEmail이 true를 반환해야 한다")
+    fun `이미 등록된 이메일은 existsByEmail이 true를 반환한다`() {
+        // given
+        adapter.save(Member(email = "test@example.com", password = "hashed", nickname = "닉네임"))
+
+        // when & then
+        assertThat(adapter.existsByEmail("test@example.com")).isTrue()
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 이메일은 existsByEmail이 false를 반환해야 한다")
+    fun `등록되지 않은 이메일은 existsByEmail이 false를 반환한다`() {
+        // when & then
+        assertThat(adapter.existsByEmail("notfound@example.com")).isFalse()
+    }
+}

--- a/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/persistence/token/RefreshTokenEntityTest.kt
+++ b/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/persistence/token/RefreshTokenEntityTest.kt
@@ -1,0 +1,31 @@
+package com.jaeyong.oop.infrastructure.persistence.token
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class RefreshTokenEntityTest {
+    @Test
+    @DisplayName("RefreshTokenEntity를 생성할 수 있어야 한다")
+    fun `RefreshTokenEntity를 생성할 수 있다`() {
+        // given & when
+        val entity = RefreshTokenEntity(memberId = 1L, hashedToken = "hashed-token")
+
+        // then
+        assertThat(entity.memberId).isEqualTo(1L)
+        assertThat(entity.hashedToken).isEqualTo("hashed-token")
+    }
+
+    @Test
+    @DisplayName("해싱된 토큰을 갱신할 수 있어야 한다")
+    fun `해싱된 토큰을 갱신할 수 있다`() {
+        // given
+        val entity = RefreshTokenEntity(memberId = 1L, hashedToken = "old-token")
+
+        // when
+        entity.updateHashedToken("new-token")
+
+        // then
+        assertThat(entity.hashedToken).isEqualTo("new-token")
+    }
+}

--- a/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/persistence/token/RefreshTokenPersistenceAdapterTest.kt
+++ b/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/persistence/token/RefreshTokenPersistenceAdapterTest.kt
@@ -1,0 +1,88 @@
+package com.jaeyong.oop.infrastructure.persistence.token
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(RefreshTokenPersistenceAdapter::class)
+class RefreshTokenPersistenceAdapterTest {
+    @Autowired
+    private lateinit var adapter: RefreshTokenPersistenceAdapter
+
+    @Autowired
+    private lateinit var refreshTokenJpaRepository: RefreshTokenJpaRepository
+
+    @Test
+    @DisplayName("Refresh Token을 저장하고 조회할 수 있어야 한다")
+    fun `Refresh Token을 저장하고 조회할 수 있다`() {
+        // given
+        adapter.save(1L, "hashed-token")
+
+        // when
+        val result = adapter.findByMemberId(1L)
+
+        // then
+        assertThat(result).isEqualTo("hashed-token")
+    }
+
+    @Test
+    @DisplayName("같은 회원의 Refresh Token을 저장하면 기존 토큰이 갱신되어야 한다")
+    fun `같은 회원의 Refresh Token을 저장하면 기존 토큰이 갱신된다`() {
+        // given
+        adapter.save(1L, "old-token")
+
+        // when
+        adapter.save(1L, "new-token")
+
+        // then
+        val result = adapter.findByMemberId(1L)
+        assertThat(result).isEqualTo("new-token")
+
+        // 레코드가 1개만 존재하는지 확인 (Upsert)
+        assertThat(refreshTokenJpaRepository.findAll()).hasSize(1)
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원의 Refresh Token 조회 시 null을 반환해야 한다")
+    fun `존재하지 않는 회원의 Refresh Token 조회 시 null을 반환한다`() {
+        // when
+        val result = adapter.findByMemberId(999L)
+
+        // then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    @DisplayName("Refresh Token을 삭제하면 조회되지 않아야 한다")
+    fun `Refresh Token을 삭제하면 조회되지 않는다`() {
+        // given
+        adapter.save(1L, "hashed-token")
+
+        // when
+        adapter.deleteByMemberId(1L)
+
+        // then
+        assertThat(adapter.findByMemberId(1L)).isNull()
+    }
+
+    @Test
+    @DisplayName("서로 다른 회원의 Refresh Token은 독립적으로 관리되어야 한다")
+    fun `서로 다른 회원의 Refresh Token은 독립적으로 관리된다`() {
+        // given
+        adapter.save(1L, "token-1")
+        adapter.save(2L, "token-2")
+
+        // when
+        adapter.deleteByMemberId(1L)
+
+        // then
+        assertThat(adapter.findByMemberId(1L)).isNull()
+        assertThat(adapter.findByMemberId(2L)).isEqualTo("token-2")
+    }
+}

--- a/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/security/BcryptAdapterTest.kt
+++ b/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/security/BcryptAdapterTest.kt
@@ -1,0 +1,57 @@
+package com.jaeyong.oop.infrastructure.security
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class BcryptAdapterTest {
+    private val bcryptAdapter = BcryptAdapter()
+
+    @Test
+    @DisplayName("비밀번호를 해싱하면 원본과 달라야 한다")
+    fun `비밀번호를 해싱하면 원본과 달라야 한다`() {
+        // given
+        val rawPassword = "password123"
+
+        // when
+        val encoded = bcryptAdapter.encode(rawPassword)
+
+        // then
+        assertThat(encoded).isNotEqualTo(rawPassword)
+    }
+
+    @Test
+    @DisplayName("원본 비밀번호와 해싱된 비밀번호가 일치해야 한다")
+    fun `원본 비밀번호와 해싱된 비밀번호가 일치한다`() {
+        // given
+        val rawPassword = "password123"
+        val encoded = bcryptAdapter.encode(rawPassword)
+
+        // when & then
+        assertThat(bcryptAdapter.matches(rawPassword, encoded)).isTrue()
+    }
+
+    @Test
+    @DisplayName("같은 비밀번호를 두 번 해싱하면 서로 다른 해시값이 나와야 한다")
+    fun `같은 비밀번호를 두 번 해싱하면 서로 다른 해시값이 나온다`() {
+        // given
+        val rawPassword = "password123"
+
+        // when
+        val encoded1 = bcryptAdapter.encode(rawPassword)
+        val encoded2 = bcryptAdapter.encode(rawPassword)
+
+        // then
+        assertThat(encoded1).isNotEqualTo(encoded2)
+    }
+
+    @Test
+    @DisplayName("틀린 비밀번호는 일치하지 않아야 한다")
+    fun `틀린 비밀번호는 일치하지 않는다`() {
+        // given
+        val encoded = bcryptAdapter.encode("password123")
+
+        // when & then
+        assertThat(bcryptAdapter.matches("wrongPassword", encoded)).isFalse()
+    }
+}

--- a/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/security/JwtAdapterTest.kt
+++ b/oop-infrastructure/src/test/kotlin/com/jaeyong/oop/infrastructure/security/JwtAdapterTest.kt
@@ -1,0 +1,113 @@
+package com.jaeyong.oop.infrastructure.security
+
+import com.jaeyong.oop.common.exception.BaseException
+import com.jaeyong.oop.common.exception.ErrorCode
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+class JwtAdapterTest {
+    private val secret = "test-secret-key-must-be-at-least-256-bits-long-for-hs256-algorithm"
+    private val accessTokenExpiry = 1800000L
+    private val refreshTokenExpiry = 1209600000L
+    private val jwtAdapter = JwtAdapter(secret, accessTokenExpiry, refreshTokenExpiry)
+
+    @Test
+    @DisplayName("Access Token을 생성하고 memberId를 추출할 수 있어야 한다")
+    fun `Access Token을 생성하고 memberId를 추출할 수 있다`() {
+        // given
+        val memberId = 1L
+
+        // when
+        val token = jwtAdapter.createAccessToken(memberId)
+        val extracted = jwtAdapter.extractMemberId(token)
+
+        // then
+        assertThat(extracted).isEqualTo(memberId)
+    }
+
+    @Test
+    @DisplayName("유효한 Refresh Token은 검증을 통과해야 한다")
+    fun `유효한 Refresh Token은 검증을 통과한다`() {
+        // given
+        val memberId = 1L
+        val token = jwtAdapter.createRefreshToken(memberId)
+
+        // when & then
+        assertDoesNotThrow { jwtAdapter.validateToken(token) }
+    }
+
+    @Test
+    @DisplayName("잘못된 토큰은 INVALID_TOKEN 예외를 던져야 한다")
+    fun `잘못된 토큰은 INVALID_TOKEN 예외를 던진다`() {
+        // when & then
+        assertThatThrownBy { jwtAdapter.validateToken("invalid-token") }
+            .isInstanceOf(BaseException::class.java)
+            .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TOKEN)
+    }
+
+    @Test
+    @DisplayName("만료된 토큰은 EXPIRED_TOKEN 예외를 던져야 한다")
+    fun `만료된 토큰은 EXPIRED_TOKEN 예외를 던진다`() {
+        // given
+        val expiredJwtAdapter = JwtAdapter(secret, 0L, 0L)
+        val token = expiredJwtAdapter.createAccessToken(1L)
+
+        // when & then
+        assertThatThrownBy { jwtAdapter.validateToken(token) }
+            .isInstanceOf(BaseException::class.java)
+            .extracting("errorCode").isEqualTo(ErrorCode.EXPIRED_TOKEN)
+    }
+
+    @Test
+    @DisplayName("Refresh Token을 생성하고 memberId를 추출할 수 있어야 한다")
+    fun `Refresh Token을 생성하고 memberId를 추출할 수 있다`() {
+        // given
+        val memberId = 1L
+
+        // when
+        val token = jwtAdapter.createRefreshToken(memberId)
+        val extracted = jwtAdapter.extractMemberId(token)
+
+        // then
+        assertThat(extracted).isEqualTo(memberId)
+    }
+
+    @Test
+    @DisplayName("같은 memberId로 생성해도 Access Token과 Refresh Token은 서로 달라야 한다")
+    fun `같은 memberId로 생성해도 Access Token과 Refresh Token은 서로 다르다`() {
+        // given
+        val memberId = 1L
+
+        // when
+        val accessToken = jwtAdapter.createAccessToken(memberId)
+        val refreshToken = jwtAdapter.createRefreshToken(memberId)
+
+        // then
+        assertThat(accessToken).isNotEqualTo(refreshToken)
+    }
+
+    @Test
+    @DisplayName("다른 비밀키로 만든 토큰은 INVALID_TOKEN 예외를 던져야 한다")
+    fun `다른 비밀키로 만든 토큰은 INVALID_TOKEN 예외를 던진다`() {
+        // given
+        val anotherSecret = "another-secret-key-must-be-at-least-256-bits-long-for-hs256-algorithm"
+        val anotherJwtAdapter = JwtAdapter(anotherSecret, accessTokenExpiry, refreshTokenExpiry)
+        val token = anotherJwtAdapter.createAccessToken(1L)
+
+        // when & then
+        assertThatThrownBy { jwtAdapter.validateToken(token) }
+            .isInstanceOf(BaseException::class.java)
+            .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TOKEN)
+    }
+
+    @Test
+    @DisplayName("잘못된 토큰에서 memberId 추출 시 예외가 발생해야 한다")
+    fun `잘못된 토큰에서 memberId 추출 시 예외가 발생한다`() {
+        // when & then
+        assertThatThrownBy { jwtAdapter.extractMemberId("invalid-token") }
+            .isInstanceOf(Exception::class.java)
+    }
+}

--- a/oop-infrastructure/src/test/resources/application-test.yml
+++ b/oop-infrastructure/src/test/resources/application-test.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/oop_db
-    username: dev_user
-    password: dev_password
-    driver-class-name: org.postgresql.Driver
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
   jpa:
     hibernate:
       ddl-auto: create-drop
@@ -11,4 +11,3 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/oop-presentation/build.gradle.kts
+++ b/oop-presentation/build.gradle.kts
@@ -2,4 +2,5 @@ dependencies {
     "implementation"(project(":oop-common"))
     "implementation"(project(":oop-application"))
     "implementation"(libs.bundles.spring.web)
+    "implementation"(libs.spring.boot.validation)
 }

--- a/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/api/AuthController.kt
+++ b/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/api/AuthController.kt
@@ -1,0 +1,87 @@
+package com.jaeyong.oop.presentation.api
+
+import com.jaeyong.oop.application.command.LoginCommand
+import com.jaeyong.oop.application.command.SignupCommand
+import com.jaeyong.oop.application.usecase.AuthUseCase
+import com.jaeyong.oop.presentation.api.dto.LoginRequest
+import com.jaeyong.oop.presentation.api.dto.ReissueRequest
+import com.jaeyong.oop.presentation.api.dto.SignupRequest
+import com.jaeyong.oop.presentation.api.dto.TokenResponse
+import com.jaeyong.oop.presentation.auth.CurrentMember
+import com.jaeyong.oop.presentation.response.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 인증 관련 REST API 컨트롤러.
+ * 회원가입, 로그인, 토큰 재발급, 로그아웃 4개의 엔드포인트를 제공한다.
+ *
+ * - signup, login, reissue는 인터셉터 제외 경로 → 토큰 없이 접근 가능
+ * - logout은 인터셉터 적용 → Authorization 헤더에 Access Token 필요
+ *
+ * 컨트롤러는 요청 검증과 DTO 변환만 담당하고,
+ * 비즈니스 로직은 AuthUseCase(인바운드 포트)를 통해 서비스에 위임한다.
+ */
+@RestController
+@RequestMapping("/api/v1/auth")
+class AuthController(
+    private val authUseCase: AuthUseCase,
+) {
+    /**
+     * 회원가입 API.
+     * DTO(SignupRequest)를 검증한 뒤 Command로 변환하여 서비스에 전달한다.
+     * 성공 시 201 Created 반환. 이메일 중복 시 DUPLICATE_EMAIL 예외.
+     */
+    @PostMapping("/signup")
+    fun signup(@Valid @RequestBody request: SignupRequest, ): ResponseEntity<ApiResponse<Nothing>> {
+        authUseCase.signup(SignupCommand(request.email, request.password, request.nickname))
+        return ApiResponse.success(status = HttpStatus.CREATED)
+    }
+
+    /**
+     * 로그인 API.
+     * 이메일/비밀번호 검증 후 Access Token + Refresh Token을 발급한다.
+     * 실패 시 LOGIN_FAILED 예외 (이메일 없음/비밀번호 틀림 구분하지 않음).
+     */
+    @PostMapping("/login")
+    fun login(
+        @Valid @RequestBody request: LoginRequest,
+    ): ResponseEntity<ApiResponse<TokenResponse>> {
+        val result =
+            authUseCase.login(
+                LoginCommand(request.email, request.password),
+            )
+        return ApiResponse.success(TokenResponse(result.accessToken, result.refreshToken))
+    }
+
+    /**
+     * 토큰 재발급 API.
+     * Access Token이 만료되었을 때, Refresh Token으로 새 토큰 쌍을 발급받는다.
+     * 토큰 로테이션 방식 — 재발급 시 Refresh Token도 새로 발급되고 이전 토큰은 무효화된다.
+     */
+    @PostMapping("/reissue")
+    fun reissue(
+        @Valid @RequestBody request: ReissueRequest,
+    ): ResponseEntity<ApiResponse<TokenResponse>> {
+        val result = authUseCase.reissue(request.refreshToken)
+        return ApiResponse.success(TokenResponse(result.accessToken, result.refreshToken))
+    }
+
+    /**
+     * 로그아웃 API.
+     * @CurrentMember: 인터셉터가 토큰에서 추출한 memberId가 자동 주입된다.
+     * DB에서 Refresh Token을 삭제하여 이후 재발급을 차단한다.
+     */
+    @PostMapping("/logout")
+    fun logout(
+        @CurrentMember memberId: Long,
+    ): ResponseEntity<ApiResponse<Nothing>> {
+        authUseCase.logout(memberId)
+        return ApiResponse.success()
+    }
+}

--- a/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/api/HealthController.kt
+++ b/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/api/HealthController.kt
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/health")
 class HealthController(
-    private val healthCheckUseCase: HealthCheckUseCase
+    private val healthCheckUseCase: HealthCheckUseCase,
 ) {
     @GetMapping
     fun healthCheck(): ResponseEntity<ApiResponse<String>> {

--- a/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/api/dto/LoginRequest.kt
+++ b/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/api/dto/LoginRequest.kt
@@ -1,0 +1,16 @@
+package com.jaeyong.oop.presentation.api.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+/**
+ * 로그인 요청 DTO.
+ * 컨트롤러에서 @Valid로 검증한 뒤, LoginCommand로 변환하여 서비스에 전달한다.
+ */
+data class LoginRequest(
+    @field:NotBlank
+    @field:Email
+    val email: String,
+    @field:NotBlank
+    val password: String,
+)

--- a/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/api/dto/ReissueRequest.kt
+++ b/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/api/dto/ReissueRequest.kt
@@ -1,0 +1,12 @@
+package com.jaeyong.oop.presentation.api.dto
+
+import jakarta.validation.constraints.NotBlank
+
+/**
+ * 토큰 재발급 요청 DTO.
+ * Access Token이 만료됐을 때, 클라이언트가 Refresh Token을 보내 새 토큰 쌍을 받는다.
+ */
+data class ReissueRequest(
+    @field:NotBlank
+    val refreshToken: String,
+)

--- a/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/api/dto/SignupRequest.kt
+++ b/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/api/dto/SignupRequest.kt
@@ -1,0 +1,23 @@
+package com.jaeyong.oop.presentation.api.dto
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+/**
+ * 회원가입 요청 DTO.
+ * 컨트롤러에서 @Valid로 검증한 뒤, SignupCommand로 변환하여 서비스에 전달한다.
+ */
+data class SignupRequest(
+    @field:NotBlank
+    @field:Email // 이메일 형식 검증 (예: user@example.com)
+    val email: String,
+    @field:NotBlank
+    @field:Size(min = 8) // 최소 8자
+    @field:Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).+$", message = "영문과 숫자를 포함해야 합니다")
+    val password: String,
+    @field:NotBlank
+    @field:Size(min = 2, max = 20) // 2~20자
+    val nickname: String,
+)

--- a/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/api/dto/TokenResponse.kt
+++ b/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/api/dto/TokenResponse.kt
@@ -1,0 +1,12 @@
+package com.jaeyong.oop.presentation.api.dto
+
+/**
+ * 토큰 응답 DTO.
+ * 로그인 및 토큰 재발급 성공 시 클라이언트에게 반환된다.
+ * - accessToken: API 호출 시 Authorization 헤더에 넣어 사용 (유효기간 30분)
+ * - refreshToken: Access Token 만료 시 재발급 요청에 사용 (유효기간 14일)
+ */
+data class TokenResponse(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/auth/CurrentMember.kt
+++ b/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/auth/CurrentMember.kt
@@ -1,0 +1,18 @@
+package com.jaeyong.oop.presentation.auth
+
+/**
+ * 컨트롤러 메서드 파라미터에 현재 인증된 회원의 ID를 주입하는 커스텀 어노테이션.
+ *
+ * 사용 예시:
+ * ```
+ * @PostMapping("/logout")
+ * fun logout(@CurrentMember memberId: Long)
+ * ```
+ *
+ * 동작 원리:
+ * 1. JwtAuthenticationInterceptor가 토큰에서 memberId를 추출하여 request attribute에 저장
+ * 2. CurrentMemberArgumentResolver가 이 어노테이션을 감지하여 attribute에서 memberId를 꺼내 파라미터에 주입
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CurrentMember

--- a/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/auth/interceptor/CurrentMemberArgumentResolver.kt
+++ b/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/auth/interceptor/CurrentMemberArgumentResolver.kt
@@ -1,0 +1,49 @@
+package com.jaeyong.oop.presentation.auth.interceptor
+
+import com.jaeyong.oop.presentation.auth.CurrentMember
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.core.MethodParameter
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+/**
+ * @CurrentMember 어노테이션이 붙은 컨트롤러 파라미터에
+ * 현재 인증된 회원의 ID(Long)를 자동으로 주입하는 ArgumentResolver.
+ *
+ * JwtAuthenticationInterceptor가 JWT 토큰을 검증한 뒤
+ * HttpServletRequest에 저장해 둔 memberId를 꺼내서 컨트롤러 파라미터로 전달한다.
+ *
+ * 사용 예시:
+ * ```
+ * @PostMapping("/logout")
+ * fun logout(@CurrentMember memberId: Long): ApiResponse<Unit>
+ * ```
+ */
+@Component
+class CurrentMemberArgumentResolver : HandlerMethodArgumentResolver {
+
+    /**
+     * 이 resolver가 처리할 수 있는 파라미터인지 판별한다.
+     * @CurrentMember 어노테이션이 있고 타입이 Long인 경우에만 true를 반환한다.
+     */
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.hasParameterAnnotation(CurrentMember::class.java) &&
+            parameter.parameterType == Long::class.java
+    }
+
+    /**
+     * JwtAuthenticationInterceptor가 request attribute에 저장한 memberId를 꺼내 반환한다.
+     */
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): Long {
+        val request = webRequest.getNativeRequest(HttpServletRequest::class.java)!!
+        return request.getAttribute(JwtAuthenticationInterceptor.MEMBER_ID_ATTRIBUTE) as Long
+    }
+}

--- a/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/auth/interceptor/JwtAuthenticationInterceptor.kt
+++ b/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/auth/interceptor/JwtAuthenticationInterceptor.kt
@@ -1,0 +1,55 @@
+package com.jaeyong.oop.presentation.auth.interceptor
+
+import com.jaeyong.oop.application.usecase.TokenValidationUseCase
+import com.jaeyong.oop.common.exception.BaseException
+import com.jaeyong.oop.common.exception.ErrorCode
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+
+// 모든 API 요청이 컨트롤러에 도달하기 전에 JWT 토큰을 검사하는 인터셉터.
+// WebConfig에서 등록되며, /api/** 경로에 적용된다. (회원가입/로그인 등 일부 경로는 제외)
+// 검증 성공 시 토큰에서 꺼낸 memberId를 request에 저장하고,
+// 이후 CurrentMemberArgumentResolver가 이 값을 컨트롤러 파라미터에 주입한다.
+@Component
+class JwtAuthenticationInterceptor(
+    private val tokenValidationUseCase: TokenValidationUseCase, // 토큰 검증/파싱을 담당하는 유스케이스 (실제 구현은 application의 AuthService)
+) : HandlerInterceptor {
+    companion object {
+        private const val AUTHORIZATION_HEADER = "Authorization"  // 클라이언트가 토큰을 보낼 때 사용하는 HTTP 헤더 이름
+        private const val BEARER_PREFIX = "Bearer "               // 토큰 앞에 붙는 접두사. "Bearer eyJhbG..." 형식
+        const val MEMBER_ID_ATTRIBUTE = "memberId"                // request에 회원 ID를 저장할 때 쓰는 키 이름
+    }
+
+    // Spring이 컨트롤러를 호출하기 직전에 자동으로 실행하는 메서드
+    // true 반환 → 컨트롤러로 진행, 예외 발생 → 예외 핸들러로 이동
+    override fun preHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+    ): Boolean {
+        // 1. "Authorization" 헤더를 꺼낸다. 없으면 → 401 UNAUTHORIZED
+        val header =
+            request.getHeader(AUTHORIZATION_HEADER)
+                ?: throw BaseException(ErrorCode.UNAUTHORIZED)
+
+        // 2. "Bearer "로 시작하는지 확인한다. 아니면 → 401 UNAUTHORIZED
+        if (!header.startsWith(BEARER_PREFIX)) {
+            throw BaseException(ErrorCode.UNAUTHORIZED)
+        }
+
+        // 3. "Bearer eyJhbG..." 에서 "Bearer " 부분을 잘라내고 순수 토큰만 추출
+        val token = header.substring(BEARER_PREFIX.length)
+
+        // 4. 토큰 유효성 검증 (만료 → EXPIRED_TOKEN, 변조 → INVALID_TOKEN)
+        tokenValidationUseCase.validateToken(token)
+
+        // 5. 토큰에서 memberId를 꺼내서 request에 저장
+        //    → 이후 CurrentMemberArgumentResolver가 이 값을 @CurrentMember 파라미터에 넣어준다
+        val memberId = tokenValidationUseCase.extractMemberId(token)
+        request.setAttribute(MEMBER_ID_ATTRIBUTE, memberId)
+
+        return true
+    }
+}

--- a/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/exception/GlobalExceptionHandler.kt
+++ b/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/exception/GlobalExceptionHandler.kt
@@ -29,14 +29,21 @@ import org.springframework.web.servlet.resource.NoResourceFoundException
  */
 @RestControllerAdvice
 class GlobalExceptionHandler {
-
     private val log = LoggerFactory.getLogger(javaClass)
 
-    // ── 1. 비즈니스 예외 (BaseException 하위) → 400 ──
+    // ── 1. 비즈니스 예외 (BaseException 하위) ──
     @ExceptionHandler(BaseException::class)
     fun handleBaseException(e: BaseException): ResponseEntity<ApiResponse<Nothing>> {
         log.warn("[{}]", e.errorCode.code)
-        return ApiResponse.fail(HttpStatus.BAD_REQUEST, e.errorCode.code)
+        val status =
+            when (e.errorCode) {
+                ErrorCode.UNAUTHORIZED,
+                ErrorCode.INVALID_TOKEN,
+                ErrorCode.EXPIRED_TOKEN,
+                -> HttpStatus.UNAUTHORIZED
+                else -> HttpStatus.BAD_REQUEST
+            }
+        return ApiResponse.fail(status, e.errorCode.code)
     }
 
     // ── 2. @Valid 검증 실패 → 400 ──

--- a/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/response/ApiResponse.kt
+++ b/oop-presentation/src/main/kotlin/com/jaeyong/oop/presentation/response/ApiResponse.kt
@@ -11,25 +11,29 @@ import org.springframework.http.ResponseEntity
  */
 data class ApiResponse<T>(
     val code: String,
-    val data: T?
+    val data: T?,
 ) {
     companion object {
-
         private const val SUCCESS_CODE = "SUCCESS"
 
         // ── 성공 응답 ──
 
         fun <T> success(
             data: T,
-            status: HttpStatus = HttpStatus.OK
+            status: HttpStatus = HttpStatus.OK,
         ): ResponseEntity<ApiResponse<T>> =
             ResponseEntity.status(status)
                 .body(ApiResponse(SUCCESS_CODE, data))
 
+        fun success(status: HttpStatus = HttpStatus.OK): ResponseEntity<ApiResponse<Nothing>> =
+            ResponseEntity.status(status)
+                .body(ApiResponse(SUCCESS_CODE, null))
+
         // ── 실패 응답 ──
 
         fun fail(
-            status: HttpStatus, code: String
+            status: HttpStatus,
+            code: String,
         ): ResponseEntity<ApiResponse<Nothing>> =
             ResponseEntity.status(status)
                 .body(ApiResponse(code, null))

--- a/oop-presentation/src/test/kotlin/com/jaeyong/oop/presentation/api/AuthControllerTest.kt
+++ b/oop-presentation/src/test/kotlin/com/jaeyong/oop/presentation/api/AuthControllerTest.kt
@@ -1,0 +1,254 @@
+package com.jaeyong.oop.presentation.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.jaeyong.oop.application.result.TokenResult
+import com.jaeyong.oop.application.usecase.AuthUseCase
+import com.jaeyong.oop.presentation.auth.interceptor.CurrentMemberArgumentResolver
+import com.jaeyong.oop.presentation.auth.interceptor.JwtAuthenticationInterceptor
+import com.jaeyong.oop.common.exception.BaseException
+import com.jaeyong.oop.common.exception.ErrorCode
+import com.jaeyong.oop.presentation.api.dto.LoginRequest
+import com.jaeyong.oop.presentation.api.dto.ReissueRequest
+import com.jaeyong.oop.presentation.api.dto.SignupRequest
+import com.jaeyong.oop.presentation.exception.GlobalExceptionHandler
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentMatchers
+import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.willDoNothing
+import org.mockito.BDDMockito.willThrow
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@ExtendWith(MockitoExtension::class)
+class AuthControllerTest {
+    private lateinit var mockMvc: MockMvc
+    private val objectMapper = ObjectMapper()
+
+    @Mock
+    private lateinit var authUseCase: AuthUseCase
+
+    private val currentMemberArgumentResolver = CurrentMemberArgumentResolver()
+
+    @BeforeEach
+    fun setUp() {
+        mockMvc =
+            MockMvcBuilders.standaloneSetup(AuthController(authUseCase))
+                .setControllerAdvice(GlobalExceptionHandler())
+                .setCustomArgumentResolvers(currentMemberArgumentResolver)
+                .build()
+    }
+
+    private fun <T> anyNonNull(): T {
+        ArgumentMatchers.any<T>()
+        @Suppress("UNCHECKED_CAST")
+        return null as T
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/auth/signup 성공 시 201을 반환해야 한다")
+    fun `회원가입 성공 시 201을 반환한다`() {
+        // given
+        willDoNothing().given(authUseCase).signup(anyNonNull())
+        val request = SignupRequest("test@example.com", "password1", "닉네임")
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.code").value("SUCCESS"))
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/auth/signup 이메일 형식이 잘못되면 400을 반환해야 한다")
+    fun `이메일 형식이 잘못되면 400을 반환한다`() {
+        // given
+        val request = SignupRequest("invalid-email", "password1", "닉네임")
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/auth/signup 비밀번호가 8자 미만이면 400을 반환해야 한다")
+    fun `비밀번호가 8자 미만이면 400을 반환한다`() {
+        // given
+        val request = SignupRequest("test@example.com", "pass1", "닉네임")
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/auth/signup 중복 이메일이면 400을 반환해야 한다")
+    fun `중복 이메일이면 400을 반환한다`() {
+        // given
+        willThrow(BaseException(ErrorCode.DUPLICATE_EMAIL)).given(authUseCase).signup(anyNonNull())
+        val request = SignupRequest("test@example.com", "password1", "닉네임")
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value("A006"))
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/auth/login 성공 시 토큰을 반환해야 한다")
+    fun `로그인 성공 시 토큰을 반환한다`() {
+        // given
+        val tokenResult = TokenResult("access-token", "refresh-token")
+        given(authUseCase.login(anyNonNull())).willReturn(tokenResult)
+        val request = LoginRequest("test@example.com", "password1")
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.code").value("SUCCESS"))
+            .andExpect(jsonPath("$.data.accessToken").value("access-token"))
+            .andExpect(jsonPath("$.data.refreshToken").value("refresh-token"))
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/auth/login 실패 시 400을 반환해야 한다")
+    fun `로그인 실패 시 400을 반환한다`() {
+        // given
+        given(authUseCase.login(anyNonNull())).willThrow(BaseException(ErrorCode.LOGIN_FAILED))
+        val request = LoginRequest("test@example.com", "wrongPassword")
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value("A003"))
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/auth/reissue 성공 시 새 토큰을 반환해야 한다")
+    fun `토큰 재발급 성공 시 새 토큰을 반환한다`() {
+        // given
+        val tokenResult = TokenResult("new-access", "new-refresh")
+        given(authUseCase.reissue("valid-refresh-token")).willReturn(tokenResult)
+        val request = ReissueRequest("valid-refresh-token")
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/auth/reissue")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.accessToken").value("new-access"))
+            .andExpect(jsonPath("$.data.refreshToken").value("new-refresh"))
+    }
+
+    // ── 유효성 검증 추가 케이스 ──
+
+    @Test
+    @DisplayName("POST /api/v1/auth/signup 닉네임이 2자 미만이면 400을 반환해야 한다")
+    fun `닉네임이 2자 미만이면 400을 반환한다`() {
+        // given
+        val request = SignupRequest("test@example.com", "password1", "A")
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/auth/signup 비밀번호에 영문이 없으면 400을 반환해야 한다")
+    fun `비밀번호에 영문이 없으면 400을 반환한다`() {
+        // given
+        val request = SignupRequest("test@example.com", "12345678", "닉네임")
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/auth/login 이메일 형식이 잘못되면 400을 반환해야 한다")
+    fun `로그인 이메일 형식이 잘못되면 400을 반환한다`() {
+        // given
+        val request = LoginRequest("invalid-email", "password1")
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/auth/reissue refreshToken이 비어있으면 400을 반환해야 한다")
+    fun `refreshToken이 비어있으면 400을 반환한다`() {
+        // given
+        val request = ReissueRequest("")
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/auth/reissue")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    // ── 로그아웃 테스트 ──
+
+    @Test
+    @DisplayName("POST /api/v1/auth/logout 성공 시 200을 반환해야 한다")
+    fun `로그아웃 성공 시 200을 반환한다`() {
+        // given
+        willDoNothing().given(authUseCase).logout(1L)
+
+        // when & then
+        mockMvc.perform(
+            post("/api/v1/auth/logout")
+                .requestAttr(JwtAuthenticationInterceptor.MEMBER_ID_ATTRIBUTE, 1L),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.code").value("SUCCESS"))
+    }
+}

--- a/oop-presentation/src/test/kotlin/com/jaeyong/oop/presentation/api/HealthControllerTest.kt
+++ b/oop-presentation/src/test/kotlin/com/jaeyong/oop/presentation/api/HealthControllerTest.kt
@@ -16,7 +16,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @WebMvcTest(HealthController::class)
 class HealthControllerTest {
-
     @SpringBootApplication
     class TestApplication
 
@@ -34,8 +33,10 @@ class HealthControllerTest {
         given(healthCheckUseCase.checkHealth()).willReturn(expectedResult)
 
         // when & then
-        mockMvc.perform(get("/api/health")
-            .contentType(MediaType.APPLICATION_JSON))
+        mockMvc.perform(
+            get("/api/health")
+                .contentType(MediaType.APPLICATION_JSON),
+        )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.code").value("SUCCESS"))
             .andExpect(jsonPath("$.data").value(expectedResult))

--- a/oop-presentation/src/test/kotlin/com/jaeyong/oop/presentation/api/exception/ErrorCodeTest.kt
+++ b/oop-presentation/src/test/kotlin/com/jaeyong/oop/presentation/api/exception/ErrorCodeTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 class ErrorCodeTest {
-
     @Test
     @DisplayName("ErrorCode의 각 항목은 고유한 코드를 가져야 한다")
     fun testErrorCodeProperties() {

--- a/oop-presentation/src/test/kotlin/com/jaeyong/oop/presentation/auth/interceptor/CurrentMemberArgumentResolverTest.kt
+++ b/oop-presentation/src/test/kotlin/com/jaeyong/oop/presentation/auth/interceptor/CurrentMemberArgumentResolverTest.kt
@@ -1,0 +1,61 @@
+package com.jaeyong.oop.presentation.auth.interceptor
+
+import com.jaeyong.oop.presentation.auth.CurrentMember
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.core.MethodParameter
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.web.context.request.ServletWebRequest
+
+class CurrentMemberArgumentResolverTest {
+    private val resolver = CurrentMemberArgumentResolver()
+
+    @Test
+    @DisplayName("@CurrentMember Long 파라미터를 지원해야 한다")
+    fun `CurrentMember Long 파라미터를 지원한다`() {
+        // given
+        val parameter = getMethodParameter("withCurrentMember")
+
+        // when & then
+        assertThat(resolver.supportsParameter(parameter)).isTrue()
+    }
+
+    @Test
+    @DisplayName("@CurrentMember가 없는 파라미터는 지원하지 않아야 한다")
+    fun `CurrentMember가 없는 파라미터는 지원하지 않는다`() {
+        // given
+        val parameter = getMethodParameter("withoutCurrentMember")
+
+        // when & then
+        assertThat(resolver.supportsParameter(parameter)).isFalse()
+    }
+
+    @Test
+    @DisplayName("request attribute에서 memberId를 꺼내 반환해야 한다")
+    fun `request attribute에서 memberId를 꺼내 반환한다`() {
+        // given
+        val request = MockHttpServletRequest()
+        request.setAttribute(JwtAuthenticationInterceptor.MEMBER_ID_ATTRIBUTE, 1L)
+        val webRequest = ServletWebRequest(request)
+        val parameter = getMethodParameter("withCurrentMember")
+
+        // when
+        val memberId = resolver.resolveArgument(parameter, null, webRequest, null)
+
+        // then
+        assertThat(memberId).isEqualTo(1L)
+    }
+
+    // 테스트용 메서드 — 파라미터의 어노테이션 유무로 supportsParameter를 검증한다
+    @Suppress("unused")
+    fun withCurrentMember(@CurrentMember memberId: Long) {}
+
+    @Suppress("unused")
+    fun withoutCurrentMember(memberId: Long) {}
+
+    private fun getMethodParameter(methodName: String): MethodParameter {
+        val method = this::class.java.getMethod(methodName, Long::class.java)
+        return MethodParameter(method, 0)
+    }
+}

--- a/oop-presentation/src/test/kotlin/com/jaeyong/oop/presentation/auth/interceptor/JwtAuthenticationInterceptorTest.kt
+++ b/oop-presentation/src/test/kotlin/com/jaeyong/oop/presentation/auth/interceptor/JwtAuthenticationInterceptorTest.kt
@@ -1,0 +1,102 @@
+package com.jaeyong.oop.presentation.auth.interceptor
+
+import com.jaeyong.oop.application.usecase.TokenValidationUseCase
+import com.jaeyong.oop.common.exception.BaseException
+import com.jaeyong.oop.common.exception.ErrorCode
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+@ExtendWith(MockitoExtension::class)
+class JwtAuthenticationInterceptorTest {
+    @Mock
+    private lateinit var tokenValidationUseCase: TokenValidationUseCase
+
+    @InjectMocks
+    private lateinit var interceptor: JwtAuthenticationInterceptor
+
+    private val response = MockHttpServletResponse()
+    private val handler = Any()
+
+    @Test
+    @DisplayName("Authorization 헤더가 없으면 UNAUTHORIZED 예외를 던져야 한다")
+    fun `Authorization 헤더가 없으면 UNAUTHORIZED 예외를 던진다`() {
+        // given
+        val request = MockHttpServletRequest()
+
+        // when & then
+        assertThatThrownBy { interceptor.preHandle(request, response, handler) }
+            .isInstanceOf(BaseException::class.java)
+            .extracting("errorCode").isEqualTo(ErrorCode.UNAUTHORIZED)
+    }
+
+    @Test
+    @DisplayName("Bearer 접두사가 없으면 UNAUTHORIZED 예외를 던져야 한다")
+    fun `Bearer 접두사가 없으면 UNAUTHORIZED 예외를 던진다`() {
+        // given
+        val request = MockHttpServletRequest()
+        request.addHeader("Authorization", "Token some-token")
+
+        // when & then
+        assertThatThrownBy { interceptor.preHandle(request, response, handler) }
+            .isInstanceOf(BaseException::class.java)
+            .extracting("errorCode").isEqualTo(ErrorCode.UNAUTHORIZED)
+    }
+
+    @Test
+    @DisplayName("유효한 토큰이면 memberId를 request attribute에 저장해야 한다")
+    fun `유효한 토큰이면 memberId를 request attribute에 저장한다`() {
+        // given
+        val request = MockHttpServletRequest()
+        request.addHeader("Authorization", "Bearer valid-token")
+        `when`(tokenValidationUseCase.extractMemberId("valid-token")).thenReturn(1L)
+
+        // when
+        val result = interceptor.preHandle(request, response, handler)
+
+        // then
+        assertThat(result).isTrue()
+        assertThat(request.getAttribute("memberId")).isEqualTo(1L)
+        verify(tokenValidationUseCase).validateToken("valid-token")
+        verify(tokenValidationUseCase).extractMemberId("valid-token")
+    }
+
+    @Test
+    @DisplayName("만료된 토큰이면 EXPIRED_TOKEN 예외를 던져야 한다")
+    fun `만료된 토큰이면 EXPIRED_TOKEN 예외를 던진다`() {
+        // given
+        val request = MockHttpServletRequest()
+        request.addHeader("Authorization", "Bearer expired-token")
+        `when`(tokenValidationUseCase.validateToken("expired-token"))
+            .thenThrow(BaseException(ErrorCode.EXPIRED_TOKEN))
+
+        // when & then
+        assertThatThrownBy { interceptor.preHandle(request, response, handler) }
+            .isInstanceOf(BaseException::class.java)
+            .extracting("errorCode").isEqualTo(ErrorCode.EXPIRED_TOKEN)
+    }
+
+    @Test
+    @DisplayName("변조된 토큰이면 INVALID_TOKEN 예외를 던져야 한다")
+    fun `변조된 토큰이면 INVALID_TOKEN 예외를 던진다`() {
+        // given
+        val request = MockHttpServletRequest()
+        request.addHeader("Authorization", "Bearer tampered-token")
+        `when`(tokenValidationUseCase.validateToken("tampered-token"))
+            .thenThrow(BaseException(ErrorCode.INVALID_TOKEN))
+
+        // when & then
+        assertThatThrownBy { interceptor.preHandle(request, response, handler) }
+            .isInstanceOf(BaseException::class.java)
+            .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TOKEN)
+    }
+}

--- a/oop-presentation/src/test/kotlin/com/jaeyong/oop/presentation/exception/GlobalExceptionHandlerTest.kt
+++ b/oop-presentation/src/test/kotlin/com/jaeyong/oop/presentation/exception/GlobalExceptionHandlerTest.kt
@@ -30,7 +30,6 @@ import org.springframework.web.servlet.resource.NoResourceFoundException
 
 @ExtendWith(MockitoExtension::class)
 class GlobalExceptionHandlerTest {
-
     private lateinit var mockMvc: MockMvc
 
     @Mock
@@ -38,9 +37,10 @@ class GlobalExceptionHandlerTest {
 
     @BeforeEach
     fun setUp() {
-        mockMvc = MockMvcBuilders.standaloneSetup(HealthController(healthCheckUseCase))
-            .setControllerAdvice(GlobalExceptionHandler())
-            .build()
+        mockMvc =
+            MockMvcBuilders.standaloneSetup(HealthController(healthCheckUseCase))
+                .setControllerAdvice(GlobalExceptionHandler())
+                .build()
     }
 
     @Test

--- a/oop-presentation/src/test/kotlin/com/jaeyong/oop/presentation/response/ApiResponseTest.kt
+++ b/oop-presentation/src/test/kotlin/com/jaeyong/oop/presentation/response/ApiResponseTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 
 class ApiResponseTest {
-
     @Test
     @DisplayName("success 응답 생성 시 SUCCESS 코드와 데이터가 포함되어야 한다")
     fun `success should create correct response`() {
@@ -37,7 +36,7 @@ class ApiResponseTest {
         assertThat(responseEntity.statusCode).isEqualTo(status)
         assertThat(responseEntity.body).isNotNull
         assertThat(responseEntity.body?.code).isEqualTo(errorCode)
-        
+
         // Use an explicit cast to avoid ambiguity with null
         val data: Any? = responseEntity.body?.data
         assertThat(data).isNull()


### PR DESCRIPTION
## 🛠️ 작업 내용
- JWT 기반 회원가입, 로그인, 토큰 재발급, 로그아웃 API 구현
- `AuthService`, `AuthUseCase`, `TokenValidationUseCase`를 중심으로 인증 유스케이스 추가
- `Member`, `MemberPort`, `JwtPort`, `PasswordEncodePort`, `RefreshTokenPort` 등 인증 관련 도메인/포트 계약 추가
- `MemberPersistenceAdapter`, `RefreshTokenPersistenceAdapter`, `JwtAdapter`, `BcryptAdapter`구현
- Spring Security 없이 `JwtAuthenticationInterceptor`, `CurrentMemberArgumentResolver`, `@CurrentMember`로 인증 흐름 구성
- `WebConfig`에 인증 인터셉터와 ArgumentResolver를 등록하고 인증 제외 경로를 설정
- `ErrorCode`, `ApiResponse`, `GlobalExceptionHandler`를 인증 흐름에 맞게 확장
- JWT 인증 관련 테스트를 추가했고, 별도로 ktlint 기준에 맞춘 health/공통 코드 포맷 정리를 반영
- PR 크기 라벨링 GitHub Actions 워크플로를 추가

## ⚡️ Issue number & Link
- #10
- #7 

## 📝 체크리스트
- [ ] JWT 회원가입/로그인/재발급/로그아웃 API 동작 확인
- [ ] 인터셉터 기반 인증 흐름 및 인증 제외 경로 확인
- [ ] Refresh Token 해싱 저장 및 재발급 로테이션 확인
- [ ] reviewer / assignee / label 설정